### PR TITLE
Fix monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2022-05-19
+
+### Fixed
+- Prometheus-node-exporter tried to add pods in fargate nodes (fargate doesn't support daemonsets) [Issue #3](https://github.com/nimbux911/terraform-aws-eks/issues/3)
+- OTEL manifests failed because namespace didn't exist [Issue #2](https://github.com/nimbux911/terraform-aws-eks/issues/2)
+- cert-manager release failed because namespace didn't exist
+
+### Added
+- ignore_change option for asg desired_capacity, to be handled by the cluster-autoscaler
+
 ## [3.0.0] - 2022-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ module "eks_main" {
 | min\_size | Minimum size of the autoscaling for the worker nodes. | `string` | `""` | yes |
 | max\_pods\_per\_node | Max pods per Kubernetes worker node. | `string` | `"100"` | no |
 | desired\_capacity | Desired size of the autoscaling for the worker nodes. | `string` | `""` | yes |
+| ignore\_desired\_capacity | Add ignore_changes to desired_capacity | `bool` | `false` | no |
 | eks\_worker\_ami\_id | AMI ID for the worker nodes | `string` | `""` | yes |
 | target\_group\_arns | ARNs of the target groups for using the worker nodes behind of ELB | `list[string]` | `[]` | no |
 | health\_check\_type | Health check type for the worker nodes. | `string` | `"EC2"` | no |

--- a/asg.tf
+++ b/asg.tf
@@ -34,7 +34,7 @@ resource "aws_launch_configuration" "eks" {
 }
 
 resource "aws_autoscaling_group" "eks" {
-  count                = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? 0 : 1
+  count                = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? 0 : 1
   desired_capacity     = var.desired_capacity
   launch_configuration = aws_launch_configuration.eks.id
   max_size             = var.max_size
@@ -63,7 +63,7 @@ resource "aws_autoscaling_group" "eks" {
 }
 
 resource "aws_autoscaling_group" "eks_ignore_desired_capacity" {
-  count                = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? 1 : 0
+  count                = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? 1 : 0
   desired_capacity     = var.desired_capacity
   launch_configuration = aws_launch_configuration.eks.id
   max_size             = var.max_size

--- a/asg.tf
+++ b/asg.tf
@@ -34,6 +34,7 @@ resource "aws_launch_configuration" "eks" {
 }
 
 resource "aws_autoscaling_group" "eks" {
+  count                = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? 0 : 1
   desired_capacity     = var.desired_capacity
   launch_configuration = aws_launch_configuration.eks.id
   max_size             = var.max_size
@@ -59,11 +60,37 @@ resource "aws_autoscaling_group" "eks" {
     var.asg_tags,
   )
 
-  dynamic "lifecycle" {
-    for_each = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? ["do it"] : []
-    content {
-      ignore_changes = [desired_capacity]
-    }
+}
+
+resource "aws_autoscaling_group" "eks_ignore_desired_capacity" {
+  count                = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? 1 : 0
+  desired_capacity     = var.desired_capacity
+  launch_configuration = aws_launch_configuration.eks.id
+  max_size             = var.max_size
+  min_size             = var.min_size
+  name                 = var.cluster_name
+  vpc_zone_identifier  = var.subnets_ids
+  target_group_arns    = var.target_group_arns
+  health_check_type    = var.health_check_type
+
+  tags = concat(
+    [
+      {
+        "key"                 = "Name"
+        "value"               = var.cluster_name
+        "propagate_at_launch" = true
+      },
+      {
+        "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.main.name}"
+        "value"               = "owned"
+        "propagate_at_launch" = true
+      },
+    ],
+    var.asg_tags,
+  )
+
+  lifecycle {
+    ignore_changes = [desired_capacity]
   }
 
 }

--- a/asg.tf
+++ b/asg.tf
@@ -58,5 +58,12 @@ resource "aws_autoscaling_group" "eks" {
     ],
     var.asg_tags,
   )
-  
+
+  dynamic "lifecycle" {
+    for_each = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? ["do it"] : []
+    content {
+      ignore_changes = [desired_capacity]
+    }
+  }
+
 }

--- a/helm.tf
+++ b/helm.tf
@@ -83,12 +83,13 @@ resource "helm_release" "metrics_server" {
 }
 
 resource "helm_release" "cert_manager" {
-  count      = var.helm_cert_manager_enabled || var.k8s_opentelemetry_enabled ? 1 : 0
-  name       = "cert-manager"
-  namespace  = "cert-manager"
-  repository = "https://charts.jetstack.io"
-  chart      = "cert-manager"
-  version    = "1.6.1"
+  count             = var.helm_cert_manager_enabled || var.k8s_opentelemetry_enabled ? 1 : 0
+  name              = "cert-manager"
+  namespace         = "cert-manager"
+  repository        = "https://charts.jetstack.io"
+  chart             = "cert-manager"
+  create_namespace  = true
+  version           = "1.6.1"
 
   set {
     name  = "installCRDs"

--- a/helm.tf
+++ b/helm.tf
@@ -122,6 +122,11 @@ resource "helm_release" "prometheus_stack" {
     value = var.prometheus_replicas
   }  
 
+  set {
+    name = "prometheus-node-exporter.nodeSelector.node\\.kubernetes\\.io/instance-type"
+    value = var.instance_type
+  }
+
   dynamic "set" {
     for_each = var.prometheus_requests_cpu != null ? ["do it"] : []
     content {
@@ -638,6 +643,10 @@ resource "helm_release" "fluent_bit" {
     file("${path.module}/helm-values/fluent-bit.yaml")
   ]
 
+  set {
+    name = "nodeSelector.node\\.kubernetes\\.io/instance-type"
+    value = var.instance_type
+  }
 
 }
 

--- a/k8s.tf
+++ b/k8s.tf
@@ -3,66 +3,66 @@
 resource "kubernetes_manifest" "otel-cert-operator-serving" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-cert-operator-serving.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrolebinding-operator-manager" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrolebinding-operator-manager.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrolebinding-operator-proxy" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrolebinding-operator-proxy.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrole-operator-manager" {
   count             = var.k8s_opentelemetry_enabled ? 1 : 0
   manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-manager.yaml"))
 
-  depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrole-operator-metrics-reader" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-metrics-reader.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrole-operator-proxy" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-proxy.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-crd-collectors" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-crd-collectors.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-crd-instrumentations" {
   count             = var.k8s_opentelemetry_enabled ? 1 : 0
   manifest = yamldecode(file("${path.module}/k8s-manifests/otel-crd-instrumentations.yaml"))
    
-  depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-deployment-operator-controller-manager" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-deployment-operator-controller-manager.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-issuer-operator-selfsigned" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-issuer-operator-selfsigned.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
-resource "kubernetes_manifest" "otel-ns-operator-system" {
+resource "kubernetes_manifest" "otel-ns-operator-system" { 
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-ns-operator-system.yaml"))
     depends_on = [helm_release.cert_manager]
@@ -71,41 +71,41 @@ resource "kubernetes_manifest" "otel-ns-operator-system" {
 resource "kubernetes_manifest" "otel-rolebinding-operator-leader-election" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-rolebinding-operator-leader-election.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-role-operator-system" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-role-operator-system.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-sa-operator-controller-manager" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-sa-operator-controller-manager.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-svc-operator-controller-manager" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-svc-operator-controller-manager.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-svc-operator-webhook" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-svc-operator-webhook.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-webhookconfig" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-webhookconfig.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-webhookvalidation" {
     count             = var.k8s_opentelemetry_enabled ? 1 : 0
     manifest = yamldecode(file("${path.module}/k8s-manifests/otel-webhookvalidation.yaml"))
-    depends_on = [helm_release.cert_manager]
+    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "worker_role_id" {
 }
 
 output "asg_name" {
-  value = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity.name : aws_autoscaling_group.eks.name
+  value = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity[0].name : aws_autoscaling_group.eks[0].name
 }
 
 output "eks_certificate_authority" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "worker_role_id" {
 }
 
 output "asg_name" {
-  value = aws_autoscaling_group.eks.name
+  value = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity.name : aws_autoscaling_group.eks.name
 }
 
 output "eks_certificate_authority" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "worker_role_id" {
 }
 
 output "asg_name" {
-  value = var.ignore_desired_capacity || var.helm_cert_manager_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity[0].name : aws_autoscaling_group.eks[0].name
+  value = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity[0].name : aws_autoscaling_group.eks[0].name
 }
 
 output "eks_certificate_authority" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,9 @@ variable "max_size" {}
 variable "min_size" {}
 variable "max_pods_per_node"{}
 variable "desired_capacity" {}
+variable "ignore_desired_capacity" {
+    default = false
+}
 variable "eks_worker_ami_id" {}
 variable "target_group_arns" {
     default = []


### PR DESCRIPTION
### Fixed
- Prometheus-node-exporter tried to add pods in fargate nodes (fargate doesn't support daemonsets) [Issue #3](https://github.com/nimbux911/terraform-aws-eks/issues/3)
- OTEL manifests failed because namespace didn't exist [Issue #2](https://github.com/nimbux911/terraform-aws-eks/issues/2)
- cert-manager release failed because namespace didn't exist

### Added
- ignore_change option for asg desired_capacity, to be handled by the cluster-autoscaler
