### PR TITLE
fixing fluent-bit service config and updating docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2022-06-02
+
+### Fixed
+- fluent-bit service parsers config
+- module source un README. Ssh url replaced for https instead
+
 ## [3.1.0] - 2022-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ locals {
       "user_arn" = "arn:aws:iam::123456789123:user/demo"
       "k8s_user" = "demo"
       "k8s_groups" = [
-        "system:masters"
+        "system:masters",
         "system:developers"
         ]
       }
@@ -49,7 +49,7 @@ locals {
 
 
 module "eks_main" {
-  source                                      = "git@github.com:nimbux911/terraform-aws-eks.git"
+  source                                      = "github.com/nimbux911/terraform-aws-eks.git"
   environment                                 = "dev"
   cluster_name                                = "dev-eks-main"
   cluster_version                             = "1.21"

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -11,8 +11,7 @@ config:
         Daemon Off
         Flush {{ .Values.flush }}
         Log_Level {{ .Values.logLevel }}
-        Parsers_File parsers.conf
-        Parsers_File custom_parsers.conf
+        Parsers_File /fluent-bit/etc/custom_parsers.conf
         HTTP_Server On
         HTTP_Listen 0.0.0.0
         HTTP_Port {{ .Values.metricsPort }}


### PR DESCRIPTION
## [3.1.1] - 2022-06-02

### Fixed
- fluent-bit service parsers config
- module source un README. Ssh url replaced for https instead
