### PR TITLE
add missing values for ingress-nginx and kube-stack-prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.2] - 2022-06-03
+
+### Fixed
+- ingress-nginx metrics expose to Prometheus
+
 ## [3.1.1] - 2022-06-02
 
 ### Fixed

--- a/helm-values/ingress-nginx.yaml
+++ b/helm-values/ingress-nginx.yaml
@@ -17,3 +17,7 @@ controller:
       annotations: 
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
+
+    serviceMonitor:
+      additionalLabels:
+        release: kube-prometheus-stack

--- a/helm.tf
+++ b/helm.tf
@@ -23,6 +23,14 @@ resource "helm_release" "ingress_nginx" {
     }
   }
 
+  dynamic "set" {
+    for_each = var.helm_prometheus_enabled != null ? ["do it"] : []
+    content {
+      name  = "controller.metrics.serviceMonitor.enabled"
+      value = true
+    }
+  }
+
   set {
     name  = "controller.service.nodePorts.http"
     value = var.ingress_http_nodeport
@@ -121,6 +129,16 @@ resource "helm_release" "prometheus_stack" {
   set {
     name  = "prometheus.prometheusSpec.replicas"
     value = var.prometheus_replicas
+  }  
+
+  set {
+    name  = "prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues"
+    value = false
+  }
+
+  set {
+    name  = "prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues"
+    value = false
   }  
 
   set {


### PR DESCRIPTION
### Fixed
- ingress-nginx metrics expose to Prometheus