### PR TITLE
Add node groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - multiple custom node groups
 - NodeSelector input for loki and prometheus components
 - Labels and taints for node groups
+- k8s default api version updated to "client.authentication.k8s.io/v1beta1"
+- Terraform Launch configuration replaced by Terraform launch template
 
 ### Fixed
 - [Loki issue #5909](https://github.com/grafana/loki/issues/5909#issuecomment-1120821579) with image v2.5.0-with-pr-6123-a630ae3 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2022-07-20
+
+### Added
+- AWS managed node groups
+- multiple custom node groups
+- NodeSelector input for loki and prometheus components
+- Labels and taints for node groups
+
+### Fixed
+- [Loki issue #5909](https://github.com/grafana/loki/issues/5909#issuecomment-1120821579) with image v2.5.0-with-pr-6123-a630ae3 
+
 ## [3.1.8] - 2022-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ module "eks_main" {
 | cluster\_version | Kubernetes version of the cluster. | `string` | `""` | yes |
 | managed\_node\_groups | AWS managed node groups configurations | `object(...)` | `null` | no |
 | custom\_node\_groups | Custom node groups configurations | `object(...)` | `null` | no |
-| k8s\_auth\_api | Kubernetes authentication API for Terraform providers. | `string` | `client.authentication.k8s.io/v1alpha1` | no |
+| k8s\_auth\_api | Kubernetes authentication API for Terraform providers. | `string` | `client.authentication.k8s.io/v1beta1` | no |
 | vpc\_id | VPC ID where cluster will be deployed. | `string` | `""` | yes |
 | subnets\_ids | Subnets ids from the VPC ID where the workers will be deployed. They must be, at least, from 2 differents AZs. | `list[string]` | `[]` | yes |
 | max\_pods\_per\_node | Max pods per Kubernetes worker node. | `string` | `"100"` | no |

--- a/README.md
+++ b/README.md
@@ -53,32 +53,58 @@ module "eks_main" {
   environment                                 = "dev"
   cluster_name                                = "dev-eks-main"
   cluster_version                             = "1.21"
-
   vpc_id                                      = "vpc-abcd1234"
   subnets_ids                                 = ["subnet-abc1234", "subnet-efgh5678"]
   eks_api_private                             = true
   enabled_cluster_log_types                   = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
-
   aws_auth_ignore_changes                     = false
   add_configmap_roles                         = local.configmap_roles
-
   target_group_arns                           = local.tg_arns
-
-  asg_tags                                    = local.asg_tags
   eks_tags                                    = var.eks_tags
-
   health_check_type                           = "ELB"  
 
-  min_size                                    = 2
-  max_size                                    = 6
-  desired_capacity                            = 2
-  instance_type                               = "t3.medium"
-  eks_worker_ami_id                           = var.eks_worker_ami_id
+  managed_node_groups = [
+    { 
+      name    = "monitoring-${var.cluster_name}"
+      values  = {
+        ami_id            = var.eks_worker_ami_id,
+        instance_type     = "m6a.large",
+        asg_min           = 3,
+        asg_max           = 4,
+        subnets_ids       = ["subnet-abc1234", "subnet-efgh5678"],
+        volume_type       = "gp3",
+        volume_size       = 100,
+        volume_iops       = 4000,
+        k8s_labels        = {
+          nodegroup       = "monitoring-${var.cluster_name}"
+        }
+      }
+    }
+  ]
 
-  helm_ingress_ngnix_enabled                  = true 
-  helm_cluster_autoscaler_enabled             = true
-  helm_metrics_server_enabled                 = true 
-  helm_cert_manager_enabled                   = true
+  custom_node_groups = [
+    {
+      name    = "${var.environment}-${var.cluster_name}"
+      values  = {
+        ami_id            = var.eks_worker_ami_id,
+        instance_type     = "t3.medium",
+        asg_min           = 4,
+        asg_max           = 8,
+        subnets_ids       = ["subnet-abc1234", "subnet-efgh5678"],
+        volume_type       = "gp2",
+        volume_size       = 100,
+        asg_tags          = var.asg_tags
+        k8s_labels        = {
+          nodegroup       = "${var.environment}-${var.cluster_name}"
+        }
+      }
+    }
+  ]
+
+  helm_ingress_ngnix_enabled       = true 
+  helm_cluster_autoscaler_enabled  = true
+  helm_metrics_server_enabled      = true 
+  helm_cert_manager_enabled        = true
 
   eks_addons = {
     vpc-cni = {
@@ -93,24 +119,31 @@ module "eks_main" {
   }
 
 # ================== loki-distributed ================= #
-  helm_loki_enabled                 = true
-  loki_storage_s3_bucket            = "my-bucket-loki-logs"
-  loki_s3_bucket_region             = "us-east-1"
-  loki_ingester_replicas            = 3
-  loki_distributor_min_replicas     = 2
-  loki_distributor_max_replicas     = 4
-  loki_querier_min_replicas         = 2
-  loki_querier_max_replicas         = 4
-  loki_query_frontend_min_replicas  = 2
-  loki_query_frontend_max_replicas  = 4
-  loki_gateway_enabled              = true
-  loki_gateway_min_replicas         = 2
-  loki_gateway_max_replicas         = 4
-  loki_gateway_ingress_enabled      = true
-  loki_gateway_ingress_host         = "loki.example.com"
-  loki_compactor_enabled            = true
-  loki_index_gateway_enabled        = true
-  loki_index_gateway_replicas       = 1
+  helm_loki_enabled                     = true
+  loki_storage_s3_bucket                = "my-bucket-loki-logs"
+  loki_s3_bucket_region                 = "us-east-1"
+  loki_ingester_replicas                = 3
+  loki_ingester_node_selector           = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
+  loki_distributor_min_replicas         = 2
+  loki_distributor_node_selector        = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
+  loki_distributor_max_replicas         = 4
+  loki_querier_min_replicas             = 2
+  loki_querier_max_replicas             = 4
+  loki_querier_node_selector            = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
+  loki_query_frontend_min_replicas      = 2
+  loki_query_frontend_max_replicas      = 4
+  loki_query_frontend_node_selector     = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
+  loki_gateway_enabled                  = true
+  loki_gateway_min_replicas             = 2
+  loki_gateway_max_replicas             = 4
+  loki_gateway_node_selector            = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
+  loki_gateway_ingress_enabled          = true
+  loki_gateway_ingress_host             = "loki.example.com"
+  loki_compactor_enabled                = true
+  loki_compactor_node_selector          = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
+  loki_index_gateway_enabled            = true
+  loki_index_gateway_replicas           = 1
+  loki_index_gateway_node_selector      = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
 
 # ================== fluent-bit ================== #
   helm_fluent_bit_enabled = true
@@ -121,9 +154,10 @@ module "eks_main" {
   prometheus_ingress_enabled  = true
   prometheus_ingress_host     = "prometheus.example.com"
   prometheus_requests_cpu     = "200m"
-  prometheus_requests_memory     = "1024Mi"
+  prometheus_requests_memory  = "1024Mi"
   prometheus_limits_cpu       = "500m"
-  prometheus_limits_memory       = "2048Mi"
+  prometheus_limits_memory    = "2048Mi"
+  prometheus_node_selector    = { "eks\\.amazonaws\\.com/nodegroup" = "monitoring-${var.cluster_name}" }
 
 # ================== tempo ================== #
   helm_tempo_enabled            = true
@@ -147,19 +181,14 @@ module "eks_main" {
 | environment | Environment name of the resources. | `string` | `""` | yes |
 | cluster\_name | Cluster name | `string` | `""` | yes |
 | cluster\_version | Kubernetes version of the cluster. | `string` | `""` | yes |
+| managed\_node\_groups | AWS managed node groups configurations | `object(...)` | `null` | no |
+| custom\_node\_groups | Custom node groups configurations | `object(...)` | `null` | no |
 | k8s\_auth\_api | Kubernetes authentication API for Terraform providers. | `string` | `client.authentication.k8s.io/v1alpha1` | no |
 | vpc\_id | VPC ID where cluster will be deployed. | `string` | `""` | yes |
 | subnets\_ids | Subnets ids from the VPC ID where the workers will be deployed. They must be, at least, from 2 differents AZs. | `list[string]` | `[]` | yes |
-| instance\_type | Instance type of the EC2 workers. | `string` | `""` | yes |
-| max\_size | Maximum size of the autoscaling for the worker nodes. | `string` | `""` | yes |
-| min\_size | Minimum size of the autoscaling for the worker nodes. | `string` | `""` | yes |
 | max\_pods\_per\_node | Max pods per Kubernetes worker node. | `string` | `"100"` | no |
-| desired\_capacity | Desired size of the autoscaling for the worker nodes. | `string` | `""` | yes |
-| ignore\_desired\_capacity | Add ignore_changes to desired_capacity | `bool` | `false` | no |
-| eks\_worker\_ami\_id | AMI ID for the worker nodes | `string` | `""` | yes |
 | target\_group\_arns | ARNs of the target groups for using the worker nodes behind of ELB | `list[string]` | `[]` | no |
 | health\_check\_type | Health check type for the worker nodes. | `string` | `"EC2"` | no |
-| asg\_tags | Tags to add to autoscaling group. | `list[map]` | `[]` | no |
 | eks\_tags | Tags to add to all resources except the autoscaling group. | `map` | `{}` | no |
 | eks\_api\_private | Defines it the Kubernetes API will be private or public. | `bool` | `false` | no |
 | eks\_addons | Adds EKS addons. | `map(map(string))` | `{}` | no |
@@ -182,24 +211,28 @@ module "eks_main" {
 | loki\_logs\_retention\_enabled | Enable logs retention. If s3 storage never stop growing | `bool` | `false` | no |
 | loki\_logs\_retention | Set logs retention period | `string` | `744h` | no |
 | loki\_ingester\_replicas | Loki ingester replicas | `int` | `1` | no | 
+| loki\_ingester\_node\_selector | Loki ingester nodeSelector | `map{}` | `null` | no | 
 | loki\_ingester\_storage\_class | storageClass for ingesters pv | `string` | `gp2` | no |
 | loki\_ingester\_storage\_size | size of ingesters pv | `string` | `10Gi` | no |
 | loki\_ingester\_requests\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_ingester\_requests\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_ingester\_limits\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_ingester\_limits\_memory | resources config for kubernetes pod | `string` | `null` | no |
+| loki\_distributor\_node\_selector | Loki distributor nodeSelector | `map{}` | `null` | no | 
 | loki\_distributor\_min\_replicas | loki distributor hpa min replicas | `int` | `1` | no |
 | loki\_distributor\_requests\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_distributor\_requests\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_distributor\_limits\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_distributor\_limits\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_distributor\_max\_replicas | loki distributor hpa max replicas | `int` | `1` | no |
+| loki\_querier\_node\_selector | Loki querier nodeSelector | `map{}` | `null` | no | 
 | loki\_querier\_min\_replicas | loki querier hpa min replicas | `int` | `1` | no |
 | loki\_querier\_max\_replicas | loki querier hpa max replicas | `int` | `1` | no |
 | loki\_querier\_requests\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_querier\_requests\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_querier\_limits\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_querier\_limits\_memory | resources config for kubernetes pod | `string` | `null` | no |
+| loki\_query\_frontend\_node\_selector | Loki query-frontend nodeSelector | `map{}` | `null` | no | 
 | loki\_query\_frontend\_min\_replicas | loki query-frontend hpa min replicas | `int` | `1` | no |
 | loki\_query\_frontend\_max\_replicas | loki query-frontend hpa max replicas | `int` | `1` | no |
 | loki\_query\_frontend\_requests\_cpu | resources config for kubernetes pod | `string` | `null` | no |
@@ -207,6 +240,7 @@ module "eks_main" {
 | loki\_query\_frontend\_limits\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_query\_frontend\_limits\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_gateway\_enabled | Enable loki gateway | `bool` | `false` | no |
+| loki\_gateway\_node\_selector | Loki gateway nodeSelector | `map{}` | `null` | no | 
 | loki\_gateway\_min\_replicas | loki gateway hpa min replicas | `int` | `1` | no |
 | loki\_gateway\_max\_replicas | loki gateway hpa max replicas | `int` | `1` | no |
 | loki\_gateway\_ingress\_enabled | Enable ingress for loki gateway | `bool` | `false` | no |
@@ -219,11 +253,13 @@ module "eks_main" {
 | loki\_gateway\_limits\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_gateway\_limits\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_compactor\_enabled | Enable loki compactor | `bool` | `false` | no |
+| loki\_compactor\_node\_selector | Loki compactor nodeSelector | `map{}` | `null` | no | 
 | loki\_compactor\_requests\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_compactor\_requests\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_compactor\_limits\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_compactor\_limits\_memory | resources config for kubernetes pod | `string` | `null` | no |
 | loki\_index\_gateway\_enabled | Enable loki index gateway | `bool` | `false` | no |
+| loki\_index\_gateway\_node\_selector | Loki _index gateway nodeSelector | `map{}` | `null` | no | 
 | loki\_index\_gateway\_replicas | Set loki index gateway replicas | `int` | `1` | no |
 | loki\_index\_gateway\_storage\_class | storageClass for index gateway pv | `string` | `gp2` | no |
 | loki\_index\_gateway\_storage\_size | storage size for index gateway pv | `string` | `10Gi` | no |
@@ -234,6 +270,7 @@ module "eks_main" {
 | helm\_fluent\_bit\_enabled | install fluent-bit helm chart | `bool` | `false` | no |
 | k8s\_opentelemetry\_enabled | install opentelemetry manifests | `bool` | `false` | no |
 | helm\_prometheus\_enabled | install kube-prometheus-stack helm chart | `bool` | `false` | no |
+| prometheus\_node\_selector | Prometheus components nodeSelector | `map{}` | `null` | no | 
 | prometheus\_replicas | prometheus server replicas | `int` | `1` | no |
 | prometheus\_requests\_cpu | resources config for kubernetes pod | `string` | `null` | no |
 | prometheus\_requests\_memory | resources config for kubernetes pod | `string` | `null` | no |
@@ -288,6 +325,5 @@ module "eks_main" {
 | security\_group\_worker\_arn | The ARN of the workers security group. |
 | worker\_role\_arn | The ARN of the workers IAM Role. |
 | worker\_role\_id | The ID of the workers IAM Role. |
-| asg\_name | Name of the of the workers Autoscaling Group. |
 | eks\_certificate\_authority | Cluster's certificate authority. |
 | eks\_endpoint | Cluster's endpoint. |

--- a/asg.tf
+++ b/asg.tf
@@ -60,7 +60,6 @@ resource "aws_launch_template" "eks_node_groups" {
         cluster_name        = aws_eks_cluster.main.name,
         max_pods_enabled    = var.max_pods_per_node != null ? "--use-max-pods false" : "",
         max_pods_per_node   = var.max_pods_per_node != null ? "--max-pods=${var.max_pods_per_node}" : "",
-#        node_labels         = [ for k, v in local.nodes_common_labels : "${k}=${v},"][0]
         node_labels         = can(each.value.k8s_labels) ? join(",", [ for k, v in merge(each.value.k8s_labels, local.nodes_common_labels) : "${k}=${v}"]) : join(",", [ for k,v in local.nodes_common_labels : "${k}=${v},"])
       }
     ))
@@ -138,10 +137,10 @@ resource "aws_eks_node_group" "eks" {
   node_role_arn   = can(each.value.instance_profile) ? each.value.instance_profile : aws_iam_instance_profile.eks_worker.name
   subnet_ids      = each.value.subnets_ids
 
-  labels = each.value.k8s_labels
+  labels = can(each.value.k8s_labels) ? each.value.k8s_labels : null
 
   dynamic "taint" {
-    for_each  = each.value.k8s_taint
+    for_each  = can(each.value.k8s_taint) ? each.value.k8s_taint : {}
     content {
       key     = taint.value.key
       value   = taint.value.value

--- a/asg.tf
+++ b/asg.tf
@@ -1,17 +1,7 @@
 locals {
   asg_tags = toset(var.asg_tags)
-  
-  eks_worker_userdata_max_pods_enabled = <<USERDATA
-#!/bin/bash
-set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.main.endpoint}' --b64-cluster-ca '${aws_eks_cluster.main.certificate_authority.0.data}' '${aws_eks_cluster.main.name}' --use-max-pods false --kubelet-extra-args '--max-pods=${var.max_pods_per_node}'
-USERDATA
+  nodes_common_labels = ["eks.amazonaws.com/compute-type=ec2"]
 
-  eks_worker_userdata = <<USERDATA
-#!/bin/bash
-set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.main.endpoint}' --b64-cluster-ca '${aws_eks_cluster.main.certificate_authority.0.data}' '${aws_eks_cluster.main.name}'
-USERDATA
 }
 
 
@@ -20,35 +10,84 @@ resource "aws_key_pair" "eks" {
   public_key = base64decode(aws_ssm_parameter.eks_public_key.value)
   tags = var.eks_tags
 }
- 
-resource "aws_launch_configuration" "eks" {
-  iam_instance_profile        = aws_iam_instance_profile.eks_worker.name
-  image_id                    = var.eks_worker_ami_id
-  instance_type               = var.instance_type
-  name_prefix                 = aws_eks_cluster.main.name
-  security_groups             = [aws_security_group.eks_worker.id]
-  user_data_base64            = var.eks_worker_max_pods_enabled ? base64encode(local.eks_worker_userdata_max_pods_enabled) : base64encode(local.eks_worker_userdata)
-  key_name                    = aws_key_pair.eks.key_name
- 
+
+
+
+resource "aws_launch_template" "eks_node_groups" {
+  for_each                              = merge(var.custom_node_groups, var.managed_node_groups)
+  name                                  = each.key
+  image_id                              = each.value.ami_id
+  instance_type                         = each.value.instance_type
+
+  vpc_security_group_ids                = can(each.value.extra_sg_ids) ? flatten(aws_security_group.eks_worker.id, each.value.extra_sg_ids) : [aws_security_group.eks_worker.id]
+
+  key_name                              = aws_key_pair.eks.key_name
+  instance_initiated_shutdown_behavior  = "terminate"
+  ebs_optimized                         = true
+
+  user_data                             =  base64encode(templatefile("${path.module}/resources/eks_worker_userdata.tpl", 
+      {
+        cluster_endpoint    = aws_eks_cluster.main.endpoint,
+        cluster_ca          = aws_eks_cluster.main.certificate_authority.0.data,
+        cluster_name        = aws_eks_cluster.main.name,
+        max_pods_enabled    = var.max_pods_per_node != null ? "--use-max-pods false" : "",
+        max_pods_per_node   = var.max_pods_per_node != null ? "--max-pods=${var.max_pods_per_node}" : "",
+        node_labels         = can(each.value.k8s_labels) ? join(",", concat(each.value.k8s_labels, local.nodes_common_labels)) : join(",", local.nodes_common_labels)
+      }
+    ))
+
+  block_device_mappings {
+    device_name             = "/dev/sda1"
+    ebs {
+      volume_size           = each.value.volume_size
+      volume_type           = each.value.volume_type
+      iops                  = can(each.value.volume_iops) ? each.value.volume_iops : null
+      delete_on_termination = true
+
+    }
+  }
+
+  iam_instance_profile {
+    name = can(each.value.instance_profile) ? each.value.instance_profile : aws_iam_instance_profile.eks_worker.name
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = each.key
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }
+
 }
 
+
+
 resource "aws_autoscaling_group" "eks" {
-  count                = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? 0 : 1
-  desired_capacity     = var.desired_capacity
-  launch_configuration = aws_launch_configuration.eks.id
-  max_size             = var.max_size
-  min_size             = var.min_size
-  name                 = var.cluster_name
-  vpc_zone_identifier  = var.subnets_ids
+  for_each             = var.custom_node_groups
+  min_size             = each.value.asg_min
+  desired_capacity     = each.value.asg_min
+  max_size             = each.value.asg_max
+  name                 = each.key
+  vpc_zone_identifier  = each.value.subnets_ids
   target_group_arns    = var.target_group_arns
   health_check_type    = var.health_check_type
 
+  launch_template {
+    id      = aws_launch_template.eks_node_groups[each.key].id
+    version = "$Latest"
+  }
+
   tag {
         key                 = "Name"
-        value               = var.cluster_name
+        value               = each.key
         propagate_at_launch = true
       }
 
@@ -58,46 +97,54 @@ resource "aws_autoscaling_group" "eks" {
         propagate_at_launch = true
       }
 
-  dynamic "tag" {
-    for_each = local.asg_tags
-    content {
-      key                 = each.key
-      value               = each.value
-      propagate_at_launch = true
-    }
+#  dynamic "tag" {
+#    for_each              = local.asg_tags
+#    content {
+#      key                 = each.key
+#      value               = each.value
+#      propagate_at_launch = true
+#    }
+#  }
+
+  lifecycle {
+    ignore_changes = [desired_capacity]
   }
 
 }
 
-resource "aws_autoscaling_group" "eks_ignore_desired_capacity" {
-  count                = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? 1 : 0
-  desired_capacity     = var.desired_capacity
-  launch_configuration = aws_launch_configuration.eks.id
-  max_size             = var.max_size
-  min_size             = var.min_size
-  name                 = var.cluster_name
-  vpc_zone_identifier  = var.subnets_ids
-  target_group_arns    = var.target_group_arns
-  health_check_type    = var.health_check_type
+resource "aws_eks_node_group" "eks" {
+  for_each             = var.managed_node_groups
 
-  tags = concat(
-    [
-      {
-        "key"                 = "Name"
-        "value"               = var.cluster_name
-        "propagate_at_launch" = true
-      },
-      {
-        "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.main.name}"
-        "value"               = "owned"
-        "propagate_at_launch" = true
-      },
-    ],
-    var.asg_tags,
-  )
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = each.key
+  node_role_arn   = can(each.value.instance_profile) ? each.value.instance_profile : aws_iam_instance_profile.eks_worker.name
+  subnet_ids      = each.value.subnets_ids
+
+#  dynamic "labels" {
+#    for_each  = each.value.k8s_labels
+#    content {
+#      key     = split("=", each.key)[0]
+#      value   = split("=", each.key)[1]
+#    }
+#  }
+#
+#  dynamic "taint" {
+#    for_each  = each.value.k8s_taint
+#    content {
+#      key     = each.value.key
+#      value   = each.value.value
+#      effect  = each.value.effect
+#    }
+#  }
+
+  scaling_config {
+    min_size     = each.value.asg_min
+    desired_size = each.value.asg_min
+    max_size     = each.value.asg_max
+  }
 
   lifecycle {
-    ignore_changes = [desired_capacity]
+    ignore_changes = [scaling_config[0].desired_size]
   }
 
 }

--- a/helm-values/loki-distributed.yaml
+++ b/helm-values/loki-distributed.yaml
@@ -1,4 +1,7 @@
 loki:
+  image:
+    tag: v2.5.0-with-pr-6123-a630ae3 # fix issue #5909 https://github.com/grafana/loki/issues/5909#issuecomment-1120821579
+    
   config: |
     auth_enabled: false
     server:

--- a/helm.tf
+++ b/helm.tf
@@ -141,6 +141,31 @@ resource "helm_release" "prometheus_stack" {
   }
 
   dynamic "set" {
+    for_each = var.prometheus_node_selector != null ? var.prometheus_node_selector : {}
+    content {
+      name  = "alertmanager.alertmanagerSpec.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.prometheus_node_selector != null ? var.prometheus_node_selector : {}
+    content {
+      name  = "prometheus.prometheusSpec.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.prometheus_node_selector != null ? var.prometheus_node_selector : {}
+    content {
+      name  = "prometheusOperator.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+
+  dynamic "set" {
     for_each = var.prometheus_requests_cpu != null ? ["do it"] : []
     content {
       name  = "prometheus.prometheusSpec.resources.requests.cpu"
@@ -259,6 +284,15 @@ resource "helm_release" "loki_distributed" {
 
   # loki - ingester
 
+  dynamic "set" {
+    for_each = var.loki_ingester_node_selector != null ? var.loki_ingester_node_selector : {}
+    content {
+      name  = "ingester.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+
   set {
     name  = "ingester.replicas"
     value = var.loki_ingester_replicas
@@ -313,6 +347,15 @@ resource "helm_release" "loki_distributed" {
 
   # loki - distributor
 
+  dynamic "set" {
+    for_each = var.loki_distributor_node_selector != null ? var.loki_distributor_node_selector : {}
+    content {
+      name  = "distributor.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+
   set {
     name  = "distributor.autoscaling.enabled"
     value = true
@@ -363,6 +406,14 @@ resource "helm_release" "loki_distributed" {
 
   # loki - querier
 
+  dynamic "set" {
+    for_each = var.loki_querier_node_selector != null ? var.loki_querier_node_selector : {}
+    content {
+      name  = "querier.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
   set {
     name  = "querier.autoscaling.enabled"
     value = true
@@ -411,6 +462,14 @@ resource "helm_release" "loki_distributed" {
   }
 
   # loki - query-frontend
+
+  dynamic "set" {
+    for_each = var.loki_query_frontend_node_selector != null ? var.loki_query_frontend_node_selector : {}
+    content {
+      name  = "queryFrontend.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
 
   set {
     name  = "queryFrontend.autoscaling.enabled"
@@ -467,6 +526,14 @@ resource "helm_release" "loki_distributed" {
   }
 
   dynamic "set" {
+    for_each = var.loki_compactor_node_selector != null ? var.loki_compactor_node_selector : {}
+    content {
+      name  = "compactor.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
+
+  dynamic "set" {
     for_each = var.loki_compactor_requests_cpu != null ? ["do it"] : []
     content {
       name  = "compactor.resources.requests.cpu"
@@ -504,6 +571,14 @@ resource "helm_release" "loki_distributed" {
     name  = "indexGateway.enabled"
     value = var.loki_index_gateway_enabled
   }  
+
+  dynamic "set" {
+    for_each = var.loki_index_gateway_node_selector != null ? var.loki_index_gateway_node_selector : {}
+    content {
+      name  = "indexGateway.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
 
   set {
     name  = "indexGateway.replicas"
@@ -564,6 +639,14 @@ resource "helm_release" "loki_distributed" {
     name  = "gateway.enabled"
     value = var.loki_gateway_enabled
   }  
+
+  dynamic "set" {
+    for_each = var.loki_gateway_node_selector != null ? var.loki_gateway_node_selector : {}
+    content {
+      name  = "gateway.nodeSelector.${set.key}"
+      value = set.value
+    }
+  }
 
   set {
     name  = "gateway.autoscaling.enabled"
@@ -636,7 +719,6 @@ resource "helm_release" "loki_distributed" {
     name  = "gateway.ingress.hosts[0].paths[0].pathType"
     value = var.loki_gateway_ingress_path_type
   }
-
 
 }
 

--- a/helm.tf
+++ b/helm.tf
@@ -136,8 +136,8 @@ resource "helm_release" "prometheus_stack" {
   }  
 
   set {
-    name = "prometheus-node-exporter.nodeSelector.node\\.kubernetes\\.io/instance-type"
-    value = var.instance_type
+    name = "prometheus-node-exporter.nodeSelector.eks\\.amazonaws\\.com/compute-type"
+    value = "ec2"
   }
 
   dynamic "set" {
@@ -657,8 +657,8 @@ resource "helm_release" "fluent_bit" {
   ]
 
   set {
-    name = "nodeSelector.node\\.kubernetes\\.io/instance-type"
-    value = var.instance_type
+    name = "nodeSelector.eks\\.amazonaws\\.com/compute-type"
+    value = "ec2"
   }
 
 }

--- a/iam.tf
+++ b/iam.tf
@@ -162,7 +162,7 @@ resource "aws_iam_role_policy" "cluster_autoscaler" {
           "autoscaling:TerminateInstanceInAutoScalingGroup"
         ],
         "Effect": "Allow",
-        "Resource": "${aws_autoscaling_group.eks_ignore_desired_capacity[0].arn}"
+        "Resource": "*"
       },
       {
         "Action": [

--- a/iam.tf
+++ b/iam.tf
@@ -158,18 +158,12 @@ resource "aws_iam_role_policy" "cluster_autoscaler" {
     "Statement": [
       {
         "Action": [
-          "autoscaling:SetDesiredCapacity",
-          "autoscaling:TerminateInstanceInAutoScalingGroup"
-        ],
-        "Effect": "Allow",
-        "Resource": "*"
-      },
-      {
-        "Action": [
           "autoscaling:DescribeTags",
           "autoscaling:DescribeAutoScalingGroups",
           "autoscaling:DescribeAutoScalingInstances",
           "autoscaling:DescribeLaunchConfigurations",
+          "autoscaling:SetDesiredCapacity",
+          "autoscaling:TerminateInstanceInAutoScalingGroup",
           "ec2:DescribeLaunchTemplateVersions"
         ],
         "Effect": "Allow",

--- a/nodegroups.tf
+++ b/nodegroups.tf
@@ -28,8 +28,8 @@ locals {
     }
   ]
 
-  managed_node_groups = {for node_group in var.managed_node_groups: node_group.name => merge(node_group.values, {type = "managed"})}
-  custom_node_groups = {for node_group in var.custom_node_groups: node_group.name => merge(node_group.values, {type = "custom"})}
+  managed_node_groups = var.managed_node_groups != null ? {for node_group in var.managed_node_groups: node_group.name => merge(node_group.values, {type = "managed"})} : null
+  custom_node_groups = var.custom_node_groups != null ? {for node_group in var.custom_node_groups: node_group.name => merge(node_group.values, {type = "custom"})} : null
 
 }
 
@@ -103,7 +103,7 @@ resource "aws_launch_template" "eks_node_groups" {
 
 
 resource "aws_autoscaling_group" "eks" {
-  for_each             = local.custom_node_groups
+  for_each             = local.custom_node_groups != null ? local.custom_node_groups : {}
   min_size             = each.value.asg_min
   desired_capacity     = each.value.asg_min
   max_size             = each.value.asg_max
@@ -134,7 +134,7 @@ resource "aws_autoscaling_group" "eks" {
 }
 
 resource "aws_eks_node_group" "eks" {
-  for_each             = local.managed_node_groups
+  for_each        = local.managed_node_groups != null ? local.managed_node_groups : {}
 
   cluster_name    = aws_eks_cluster.main.name
   node_group_name = each.key

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,10 +10,6 @@ output "worker_role_id" {
   value = aws_iam_role.eks_worker.id
 }
 
-#output "asg_name" {
-#  value = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity[0].name : aws_autoscaling_group.eks[0].name
-#}
-
 output "eks_certificate_authority" {
   value = aws_eks_cluster.main.certificate_authority.0.data
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,9 +10,9 @@ output "worker_role_id" {
   value = aws_iam_role.eks_worker.id
 }
 
-output "asg_name" {
-  value = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity[0].name : aws_autoscaling_group.eks[0].name
-}
+#output "asg_name" {
+#  value = var.ignore_desired_capacity || var.helm_cluster_autoscaler_enabled ? aws_autoscaling_group.eks_ignore_desired_capacity[0].name : aws_autoscaling_group.eks[0].name
+#}
 
 output "eks_certificate_authority" {
   value = aws_eks_cluster.main.certificate_authority.0.data

--- a/provider.tf
+++ b/provider.tf
@@ -1,5 +1,6 @@
 
 terraform {
+  experiments = [module_variable_optional_attrs]
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/resources/eks_worker_userdata.tpl
+++ b/resources/eks_worker_userdata.tpl
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -o xtrace
+/etc/eks/bootstrap.sh --apiserver-endpoint "${cluster_endpoint}" --b64-cluster-ca "${cluster_ca}" "${cluster_name}" ${max_pods_enabled} --kubelet-extra-args "${max_pods_per_node}" --node-labels=${node_labels}
+
+

--- a/resources/eks_worker_userdata.tpl
+++ b/resources/eks_worker_userdata.tpl
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint "${cluster_endpoint}" --b64-cluster-ca "${cluster_ca}" "${cluster_name}" ${max_pods_enabled} --kubelet-extra-args "${max_pods_per_node}" --node-labels='${node_labels}'
+/etc/eks/bootstrap.sh --apiserver-endpoint "${cluster_endpoint}" --b64-cluster-ca "${cluster_ca}" "${cluster_name}" ${max_pods_enabled} --kubelet-extra-args '${max_pods_per_node}  --node-labels=${node_labels}'
 
 

--- a/resources/eks_worker_userdata.tpl
+++ b/resources/eks_worker_userdata.tpl
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint "${cluster_endpoint}" --b64-cluster-ca "${cluster_ca}" "${cluster_name}" ${max_pods_enabled} --kubelet-extra-args "${max_pods_per_node}" --node-labels=${node_labels}
+/etc/eks/bootstrap.sh --apiserver-endpoint "${cluster_endpoint}" --b64-cluster-ca "${cluster_ca}" "${cluster_name}" ${max_pods_enabled} --kubelet-extra-args "${max_pods_per_node}" --node-labels='${node_labels}'
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,7 @@ variable "custom_node_groups"{
             })))
         })
   }))
+  default = null
 }
 
 variable "managed_node_groups"{
@@ -64,7 +65,7 @@ variable "managed_node_groups"{
             })))
         })
   }))
-
+    default = null
 }
 
 variable "k8s_auth_api" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,14 +1,71 @@
-variable "environment" {}
-variable "cluster_name" {}
-variable "cluster_version" {}
-variable "vpc_id" {}
-variable "subnets_ids" {}
+variable "environment" {
+    type = string
+}
+variable "cluster_name" {
+    type = string
+}
+variable "cluster_version" {
+    type = string
+}
+variable "vpc_id" {
+    type = string
+}
+variable "subnets_ids" {
+    type = list(string)
+}
 variable "max_pods_per_node"{
+    type    = number
     default = null
 }
 
-variable "custom_node_groups"{}
-variable "managed_node_groups"{}
+variable "custom_node_groups"{
+    type = list(object({
+        name = string
+        values = object({
+            ami_id           = string,
+            instance_type    = string,
+            extra_sg_ids     = optional(list(string)),
+            instance_profile = optional(string),
+            asg_min          = number,
+            asg_max          = number,
+            subnets_ids      = list(string),
+            volume_type      = string,
+            volume_size      = number,
+            volume_iops      = optional(number),
+            k8s_labels       = optional(map(string)),
+            asg_tags         = optional(list(object({
+                key                  = string,
+                value                = string,
+                propagate_at_launch  = bool
+            })))
+        })
+  }))
+}
+
+variable "managed_node_groups"{
+    type = list(object({
+        name = string
+        values = object({
+            ami_id          = string,
+            instance_type   = string,
+            extra_sg_ids    = optional(list(string)),
+            iam_role_arn    = optional(string),
+            asg_min         = number,
+            asg_max         = number,
+            subnets_ids     = list(string),
+            volume_type     = string,
+            volume_size     = number,
+            volume_iops     = optional(number),
+            k8s_labels      = optional(map(string)),
+            k8s_taint       = optional(list(object({
+                key     = string,
+                value   = string,
+                effect  = string
+            })))
+        })
+  }))
+
+}
 
 variable "k8s_auth_api" {
     default = "client.authentication.k8s.io/v1alpha1"

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,10 @@ variable "loki_ingester_replicas" {
     default = 1
 }
 
+variable "loki_ingester_node_selector" {
+    default = null
+}
+
 variable "loki_ingester_storage_class" {
     default = "gp2"
 }
@@ -146,6 +150,10 @@ variable "loki_distributor_min_replicas" {
     default = 1
 }
 
+variable "loki_distributor_node_selector" {
+    default = null
+}
+
 variable "loki_distributor_requests_cpu" {
     default = null
 }
@@ -166,6 +174,10 @@ variable "loki_distributor_max_replicas" {
 # loki - querier
 variable "loki_querier_min_replicas" {
     default = 1
+}
+
+variable "loki_querier_node_selector" {
+    default = null
 }
 
 variable "loki_querier_max_replicas" {
@@ -190,6 +202,10 @@ variable "loki_query_frontend_min_replicas" {
     default = 1
 }
 
+variable "loki_query_frontend_node_selector" {
+    default = null
+}
+
 variable "loki_query_frontend_max_replicas" {
     default = 1
 }
@@ -211,6 +227,10 @@ variable "loki_query_frontend_limits_memory" {
 
 variable "loki_gateway_enabled" {
     default = false
+}
+
+variable "loki_gateway_node_selector" {
+    default = null
 }
 
 variable "loki_gateway_min_replicas" {
@@ -260,6 +280,10 @@ variable "loki_compactor_enabled" {
     default = true
 }
 
+variable "loki_compactor_node_selector" {
+    default = null
+}
+
 variable "loki_compactor_requests_cpu" {
     default = null
 }
@@ -277,6 +301,10 @@ variable "loki_compactor_limits_memory" {
 
 variable "loki_index_gateway_enabled" {
     default = true
+}
+
+variable "loki_index_gateway_node_selector" {
+    default = null
 }
 
 variable "loki_index_gateway_replicas" {
@@ -313,6 +341,10 @@ variable "helm_fluent_bit_enabled" {
 # ================== prometheus ================== #
 variable "helm_prometheus_enabled" {
     default = false
+}
+
+variable "prometheus_node_selector" {
+    default = null
 }
 
 variable "prometheus_replicas" {

--- a/variables.tf
+++ b/variables.tf
@@ -69,7 +69,7 @@ variable "managed_node_groups"{
 }
 
 variable "k8s_auth_api" {
-    default = "client.authentication.k8s.io/v1alpha1"
+    default = "client.authentication.k8s.io/v1beta1"
 }
 variable "target_group_arns" {
     default = []

--- a/variables.tf
+++ b/variables.tf
@@ -3,15 +3,12 @@ variable "cluster_name" {}
 variable "cluster_version" {}
 variable "vpc_id" {}
 variable "subnets_ids" {}
-variable "instance_type" {}
-variable "max_size" {}
-variable "min_size" {}
-variable "max_pods_per_node"{}
-variable "desired_capacity" {}
-variable "ignore_desired_capacity" {
-    default = false
+variable "max_pods_per_node"{
+    default = null
 }
-variable "eks_worker_ami_id" {}
+
+variable "custom_node_groups"{}
+variable "managed_node_groups"{}
 
 variable "k8s_auth_api" {
     default = "client.authentication.k8s.io/v1alpha1"

--- a/variables.tf
+++ b/variables.tf
@@ -29,10 +29,6 @@ variable "eks_worker_ssh_cidrs" {
     default = []
 }
 
-variable "asg_tags" {
-  default = []
-}
-
 variable "eks_tags" {
     default = {}
 }


### PR DESCRIPTION
## [4.0.0] - 2022-07-20

### Added
- AWS managed node groups
- multiple custom node groups
- NodeSelector input for loki and prometheus components
- Labels and taints for node groups

### Fixed
- [Loki issue #5909](https://github.com/grafana/loki/issues/5909#issuecomment-1120821579) with image v2.5.0-with-pr-6123-a630ae3 

