### PR TITLE
Update k8s registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update kubernetes registry from k8s.gcr.io Image to registry.k8s.io, based on this [announcement](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) 
+- Update kubernetes registry from k8s.gcr.io Image to registry.k8s.io, based on this [announcement](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/)
+- Typo on Tempo Helm chart version variable name.
+- Typo on Tempo priority class name set value.
 
 ## [4.6.0] - 2023-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [4.6.1] - 2023-03-30
+
+### Fixed
+
+- Update kubernetes registry from k8s.gcr.io Image to registry.k8s.io, based on this [announcement](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) 
 
 ## [4.6.0] - 2023-02-23
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ module "eks_main" {
 | grafana\_ingress\_class\_name | ingress className | `string` | `nginx` | no |
 | grafana\_persistence\_enabled | Persistent volume | `bool` | `false` | no |
 | grafana\_priority\_class\_name | allows you to set a priority class | `string` | `""` | no |
+| k8s\_image\_registry | Kubernetes image registry. | `string` | `registry.k8s.io` | no |
 
 ## Outputs
 

--- a/helm.tf
+++ b/helm.tf
@@ -214,7 +214,7 @@ resource "helm_release" "prometheus_stack" {
 
 
   set {
-    name = "admissionWebhooks.patch.image.repository"
+    name = "prometheusOperator.admissionWebhooks.patch.image.repository"
     value = "${var.k8s_image_registry}/ingress-nginx/kube-webhook-certgen"
   }
 

--- a/helm.tf
+++ b/helm.tf
@@ -892,7 +892,7 @@ resource "helm_release" "tempo_distributed" {
   create_namespace  = true
   repository        = "https://grafana.github.io/helm-charts"
   chart             = "tempo-distributed"
-  version           = var.tempo_chart_versoin
+  version           = var.tempo_chart_version
   dependency_update = true
   timeout           = 600
 
@@ -901,7 +901,7 @@ resource "helm_release" "tempo_distributed" {
   ]
 
   set {
-    name = "prometheus_priority_class_name"
+    name = "global.priorityClassName"
     value = var.tempo_priority_class_name
   }
 

--- a/helm.tf
+++ b/helm.tf
@@ -15,6 +15,11 @@ resource "helm_release" "ingress_nginx" {
   ]
 
   set {
+    name  = "controller.image.registry"
+    value = var.k8s_image_registry
+  }
+
+  set {
     name  = "controller.metrics.enabled"
     value = var.ingress_service_monitor_enabled
   }
@@ -67,6 +72,11 @@ resource "helm_release" "ingress_nginx_additional" {
   ]
 
   set {
+    name  = "controller.image.registry"
+    value = var.k8s_image_registry
+  }
+
+  set {
     name  = "controller.metrics.enabled"
     value = var.ingress_service_monitor_enabled
   }
@@ -113,6 +123,11 @@ resource "helm_release" "cluster_autoscaler" {
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
   version    = var.cluster_autoscaler_chart_version
+
+  set {
+    name  = "image.repository"
+    value = "${var.k8s_image_registry}/autoscaling/cluster-autoscaler"
+  }
 
   set {
     name  = "autoDiscovery.clusterName"
@@ -196,6 +211,12 @@ resource "helm_release" "prometheus_stack" {
   version           = var.prometheus_chart_version
   dependency_update = true
   timeout           = 600
+
+
+  set {
+    name = "admissionWebhooks.patch.image.registry"
+    value = var.k8s_image_registry
+  }
 
   set {
     name = "prometheus.prometheusSpec.additionalScrapeConfigs"

--- a/helm.tf
+++ b/helm.tf
@@ -214,8 +214,8 @@ resource "helm_release" "prometheus_stack" {
 
 
   set {
-    name = "admissionWebhooks.patch.image.registry"
-    value = var.k8s_image_registry
+    name = "admissionWebhooks.patch.image.repository"
+    value = "${var.k8s_image_registry}/ingress-nginx/kube-webhook-certgen"
   }
 
   set {

--- a/helm.tf
+++ b/helm.tf
@@ -214,8 +214,8 @@ resource "helm_release" "prometheus_stack" {
 
 
   set {
-    name = "kube-state-metrics.image.registry"
-    value = var.k8s_image_registry
+    name = "kube-state-metrics.image.repository"
+    value = "${var.k8s_image_registry}/kube-state-metrics/kube-state-metrics"
   }
 
   set {

--- a/helm.tf
+++ b/helm.tf
@@ -214,6 +214,11 @@ resource "helm_release" "prometheus_stack" {
 
 
   set {
+    name = "kube-state-metrics.image.registry"
+    value = var.k8s_image_registry
+  }
+
+  set {
     name = "prometheusOperator.admissionWebhooks.patch.image.repository"
     value = "${var.k8s_image_registry}/ingress-nginx/kube-webhook-certgen"
   }

--- a/nodegroups.tf
+++ b/nodegroups.tf
@@ -35,10 +35,8 @@ locals {
 resource "aws_key_pair" "eks" {
   key_name   = aws_eks_cluster.main.name
   public_key = base64decode(aws_ssm_parameter.eks_public_key.value)
-  tags = var.eks_tags
+  tags       = var.eks_tags
 }
-
-
 
 resource "aws_launch_template" "eks_node_groups" {
   for_each                              = merge(local.custom_node_groups, local.managed_node_groups)
@@ -139,7 +137,6 @@ resource "aws_autoscaling_group" "eks" {
       propagate_at_launch   = tag.value.propagate_at_launch
     }
   }
-
 
   lifecycle {
     ignore_changes = [desired_capacity]

--- a/variables.tf
+++ b/variables.tf
@@ -240,7 +240,7 @@ variable "loki_chart_version" {
     default = "0.48.3"  
 }
 
-variable "loki_priorityclass" {
+variable "loki_priority_class_name" {
     default = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -575,13 +575,12 @@ variable "helm_tempo_enabled" {
     default = false
 }
 
-variable "tempo_chart_versoin" {
+variable "tempo_chart_version" {
     default = "0.17.1"  
 }
 
 variable "tempo_priority_class_name" {
     default = null
-  
 }
 
 # tempo - compactor

--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,9 @@ variable "eks_addons" {
 }
 
 # ============================== helm releases ============================== #
-
+variable "k8s_image_registry" {
+    default = "registry.k8s.io"
+}
 # ================== ingress-nginx =================
 variable "helm_ingress_nginx_enabled" {
     default = false


### PR DESCRIPTION
## Fixed
Based on this [announcement](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), I've replaced the k8s.gcr.io registry by registry.k8s.io in the following charts:
- [Prometheus](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
- [kube-state-metrics](https://github.com/prometheus-community/helm-charts/blob/prometheus-node-exporter-2.4.1/charts/kube-state-metrics/values.yaml)
- [Ingress Nginx](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml)
- [Cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/charts/cluster-autoscaler/values.yaml)