### PR TITLE
adding replica count for ingress-nginx and ingress-additional-nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.1] - 2023-07-25
+
+### Added
+- Minimun Replica count for ingress-nginx and ingress-additional-nginx
+
 ## [4.7.0] - 2023-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ module "eks_main" {
 | ingress\_requests\_memory | Set how much memory will be assigned to the request | `string` | `90Mi` | no |
 | ingress\_service\_monitor\_enabled | Enable serviceMonitor for ingress-nginx helm chart | `bool` | `false` | no |
 | ingress\_priority\_class\_name | allows you to set a priority class | `string` | `""` | no |
+| ingress\_replicacount | Minimum Replicas count of ingress | `number` | `"1"` | no |
 | helm\_ingress\_nginx\_additional\_enabled | Set if additional ingress-nginx Helm chart will be installed on the cluster. | `bool` | `false` | no |
 | ingress\_additional\_chart\_version | Set the version for the chart | `string` | `4.0.18` | no |
 | ingress\_additional\_http\_nodeport | Set port for additional ingress http nodePort | `int` | `31080` | no |
@@ -237,6 +238,7 @@ module "eks_main" {
 | ingress\_additional\_requests\_cpu | Set how much cpu will be assigned to the request | `string` | `100m` | no | 
 | ingress\_additional\_requests\_memory | Set how much memory will be assigned to the request | `string` | `90Mi` | no |
 | ingress\_additional\_priority\_class\_name | allows you to set a priority class | `string` | `""` | no |
+| ingress\_additional\_replicacount | Minimum Replicas count of ingress additional | `number` | `"1"` | no |
 | helm\_cluster\_autoscaler\_enabled | Set if cluster-autoscaler Helm chart will be installed on the cluster. | `bool` | `false` | no |
 | cluster\_autoscaler\_chart\_version | Set the version for the chart | `string` | `9.16.1` | no |
 | cluster\_autoscaler\_priority\_class\_name | allows you to set a priority class | `string` | `""` | no |

--- a/helm.tf
+++ b/helm.tf
@@ -55,6 +55,11 @@ resource "helm_release" "ingress_nginx" {
     value = var.ingress_priority_class_name
   }
 
+  set {
+    name = "controller.replicaCount"
+    value = var.ingress_replicacount
+  }
+
   depends_on = [time_sleep.wait_20_seconds]
 
 }
@@ -110,6 +115,11 @@ resource "helm_release" "ingress_nginx_additional" {
   set {
     name = "controller.priorityClassName"
     value = var.ingress_additional_priority_class_name
+  }
+  
+  set {
+    name = "controller.replicaCount"
+    value = var.ingress_additional_replicacount
   }
 
   depends_on = [time_sleep.wait_20_seconds]

--- a/variables.tf
+++ b/variables.tf
@@ -786,3 +786,15 @@ variable "grafana_persistence_enabled" {
 variable "grafana_priority_class_name" {
     default = ""
 }
+
+variable "ingress_replicacount" {
+    description = "Minimum Replicas count of ingress"
+    type        = number
+    default     = 1
+}
+
+variable "ingress_additional_replicacount" {
+    description = "Minimum Replicas count of ingress additional"
+    type        = number
+    default     = 1
+}


### PR DESCRIPTION
## [4.7.1] - 2023-07-25

## What's New
### Added
- Minimun Replica count for ingress-nginx and ingress-additional-nginx

### Note
- Added a variable called ingress_replicacount and ingress_additional_replicacount in order to set the minimun replica count available for high availability