### PR TITLE
Allow setting ingress-nginx custom configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.4.0] - 2024-08-22
+
+- Allow setting ingress-nginx custom configuration options.
+
 ## [5.3.0] - 2024-07-29
 
 - Add mixed instances policy.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ module "eks_main" {
 | enabled\_cluster\_log\_types | Enable CloudWatch Logs for control plane components | `list[string]` | `[]` | no |
 | helm\_ingress\_nginx\_enabled | Set if ingress-nginx Helm chart will be installed on the cluster. | `bool` | `false` | no |
 | ingress\_chart\_version | Set the version for the chart | `string` | `4.0.18` | no |
+| ingress\_custom\_configuration | Add custom configuration options (see controller.config in official ingress-nginx chart docs) | `string` | `null` | no |
 | ingress\_http\_nodeport | Set port for ingress http nodePort | `int` | `32080` | no |
 | ingress\_https\_nodeport | Set port for ingress https nodePort | `int` | `32443` | no |
 | ingress\_https\_traffic\_enabled | Set https traffic for ingress | `bool` | `false` | no | 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ module "eks_main" {
   eks_tags                                    = var.eks_tags
   health_check_type                           = "ELB"  
 
+  # Example for ingress-nginx log format in logfmt using real source ip as client_ip
+  ingress_custom_configuration                = "log-format-upstream: timestamp=$time_iso8601 client_ip=$http_x_forwarded_for method=$request_method uri=$request_uri status=$status http_user_agent=$http_user_agent request_length=$request_length request_time=$request_time proxy_upstream_name=$proxy_upstream_name upstream_addr=$upstream_addr upstream_response_length=$upstream_response_length upstream_response_time=$upstream_response_time upstream_status=$upstream_status req_id=$req_id" 
+
   managed_node_groups = [
     { 
       name    = "monitoring-${var.cluster_name}"
@@ -236,7 +239,7 @@ module "eks_main" {
 | enabled\_cluster\_log\_types | Enable CloudWatch Logs for control plane components | `list[string]` | `[]` | no |
 | helm\_ingress\_nginx\_enabled | Set if ingress-nginx Helm chart will be installed on the cluster. | `bool` | `false` | no |
 | ingress\_chart\_version | Set the version for the chart | `string` | `4.0.18` | no |
-| ingress\_custom\_configuration | Add custom configuration options (see controller.config in official ingress-nginx chart docs) | `string` | `null` | no |
+| ingress\_custom\_configuration | Add custom configuration options (see example above in module call inputs and https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml#L52) | `string` | `null` | no |
 | ingress\_http\_nodeport | Set port for ingress http nodePort | `int` | `32080` | no |
 | ingress\_https\_nodeport | Set port for ingress https nodePort | `int` | `32443` | no |
 | ingress\_https\_traffic\_enabled | Set https traffic for ingress | `bool` | `false` | no | 

--- a/helm-values/ingress-nginx.yaml.tpl
+++ b/helm-values/ingress-nginx.yaml.tpl
@@ -32,3 +32,8 @@ controller:
             values:
               - ${nodeAffinityLabelValue}
   %{endif}
+
+  %{ if customConfiguration != null }
+  config:
+    ${ customConfiguration }
+  %{ endif }

--- a/helm.tf
+++ b/helm.tf
@@ -15,7 +15,8 @@ resource "helm_release" "ingress_nginx" {
     {
       enableNodeAffinity = var.ingress_node_affinity["enabled"],
       nodeAffinityLabelKey = var.ingress_node_affinity["label_key"],
-      nodeAffinityLabelValue = var.ingress_node_affinity["label_value"]
+      nodeAffinityLabelValue = var.ingress_node_affinity["label_value"],
+      customConfiguration = var.ingress_custom_configuration
     })
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -218,6 +218,11 @@ variable "ingress_node_affinity" {
   }
 }
 
+variable "ingress_custom_configuration" {
+  type    = string
+  default = null
+}
+
 # ================== ingress-nginx-additional =================
 
 variable "helm_ingress_nginx_additional_enabled" {


### PR DESCRIPTION
This PR adds a module input to allow setting ingress-nginx custom (and global) configuration options.

See `controller.config` at https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx/4.0.18 for reference.