### PR TITLE
Parse logfmt logs automatically (instead of json) in fluentbit. Increase default loki-ingester CPU and MEM requests and limits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.5.0] - 2024-09-25
+
+- Parse logfmt logs automatically (instead of json) in fluentbit. Increase default loki-ingester CPU and MEM requests and limits.
+
 ## [5.4.0] - 2024-08-22
 
 - Allow setting ingress-nginx custom configuration options.

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -22,7 +22,7 @@ config:
         Name           tail
         Tag            kube.*
         Path           /var/log/containers/*.log
-        Parser         docker
+        Parser         cri
         DB             /run/fluent-bit/flb_kube.db
         Mem_Buf_Limit  5MB
   ## https://docs.fluentbit.io/manual/pipeline/filters
@@ -48,16 +48,17 @@ config:
         RemoveKeys kubernetes,stream
         AutoKubernetesLabels false
         LabelMapPath /fluent-bit/etc/labelmap.json
-        LineFormat json
+        LineFormat key_value
         LogLevel warn
 
-  ## https://docs.fluentbit.io/manual/pipeline/parsers
+  # https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
     [PARSER]
-        Name        docker
-        Format      json
+        Name cri
+        Format regex
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*)$
         Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L          
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 
   # This allows adding more files with arbitary filenames to /fluent-bit/etc by providing key/value pairs.
   # The key becomes the filename, the value becomes the file content.

--- a/helm-values/loki-distributed.yaml
+++ b/helm-values/loki-distributed.yaml
@@ -76,6 +76,7 @@ loki:
       reject_old_samples_max_age: 168h
       max_cache_freshness_per_query: 10m
       split_queries_by_interval: 15m
+      max_query_series: 1000
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig:

--- a/helm-values/loki-distributed.yaml
+++ b/helm-values/loki-distributed.yaml
@@ -6,6 +6,8 @@ loki:
     auth_enabled: false
     server:
       http_listen_port: 3100
+      grpc_server_max_recv_msg_size: 30000000
+      grpc_server_max_send_msg_size: 30000000
     distributor:
       ring:
         kvstore:
@@ -108,6 +110,13 @@ ingester:
       mountPath: /data/loki
     - name: wal
       mountPath: /data/loki/wal
+  resources:
+    requests:
+      cpu: 100m
+      memory: 500Mi
+    limits:
+      cpu: 1000m
+      memory: 2000Mi
 
 # Configuration for the index-gateway
 indexGateway:


### PR DESCRIPTION
The fluent-bit change allows automatically parsing labels in logfmt-formatted logs like this one:

```
2024-09-25T22:26:26.797667005Z stdout F timestamp=2024-09-25T22:26:26+00:00 client_ip=181.81.74.59 method=GET uri=/v1/medical_certificates/me/paginated status=200 http_user_agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 request_length=1046 request_time=0.168 proxy_upstream_name=rcta-api-http upstream_addr=172.27.86.69:80 upstream_response_length=656 upstream_response_time=0.168 upstream_status=200 req_id=8a8a6c0dbf4e1902335b08df2b13f8aa
```

For example, in the above log, the parsed labels are:

![image](https://github.com/user-attachments/assets/409f8d85-0508-4dbc-b4e8-f397b58577ab)

This way it's easier (and more performant) to perform complex queries like this one which counts requests from ingress-nginx access log and groups them by client_ip:

![image](https://github.com/user-attachments/assets/a3a7eba3-1e03-4093-ad9d-ebd3d1edc303)

The loki-ingester change increases default requests so it's more tolerant to deployments that need to handle a higher volume of logs (we can and maybe should parameterize this in a future).