### PR TITLE
adding override variable to eks module

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ module "eks_main" {
 | ingress\_additional\_chart\_version | Set the version for the chart | `string` | `4.0.18` | no |
 | ingress\_additional\_http\_nodeport | Set port for additional ingress http nodePort | `int` | `31080` | no |
 | ingress\_additional\_https\_nodeport | Set port for additional ingress https nodePort | `int` | `31443` | no |
+| override | List of instance type configurations for node groups. Can be used to specify multiple instance types for spot instances or mixed instance policies. | `list(object({ instance_type = string }))` | `null` | no |
 | ingress\_additional\_https\_traffic\_enabled | Set https traffic for additional ingress | `bool` | `false` | no | 
 | ingress\_additional\_requests\_cpu | Set how much cpu will be assigned to the request | `string` | `100m` | no | 
 | ingress\_additional\_requests\_memory | Set how much memory will be assigned to the request | `string` | `90Mi` | no |

--- a/nodegroups.tf
+++ b/nodegroups.tf
@@ -149,6 +149,13 @@ resource "aws_autoscaling_group" "eks" {
         launch_template_id      = aws_launch_template.eks_node_groups[each.key].id
         version = "$Latest"
       }
+
+      dynamic "override" {
+        for_each = each.value.override != null ? each.value.override : []
+        content {
+          instance_type = override.value.instance_type
+        }
+      }
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,9 @@ variable "custom_node_groups"{
             volume_size      = number,
             volume_iops      = optional(number),
             k8s_labels       = optional(map(string)),
+            override = optional(list(object({
+                instance_type = any  
+            })))
             asg_tags         = optional(list(object({
                 key                  = string,
                 value                = string,
@@ -61,6 +64,9 @@ variable "managed_node_groups"{
             volume_size     = number,
             volume_iops     = optional(number),
             k8s_labels      = optional(map(string)),
+            override = optional(list(object({
+                instance_type = any  
+            })))
             k8s_taint       = optional(list(object({
                 key     = string,
                 value   = string,


### PR DESCRIPTION
The `override` field is used to specify alternative configurations for EC2 instances in node groups (both managed and self-managed).

example of given override value:
```
override = {
  instance_type = ["t3a.large", "t3.large"]
}
```

This field is particularly useful in the following cases:
* When using **Spot Instances**, to improve availability by providing multiple instance types.
* When configuring mixed instance groups, allowing AWS to choose instances based on capacity and pricing.