### PR TITLE
Chore/update fluentbit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.10.0] - 2026-04-16
+
+- Upgrade Fluent Bit Helm chart to 0.57.2 and image to fluent-bit:5.0.2 versions.
+- Replace Grafana Loki plugin with the official Fluent Bit Loki output plugin.
+- Update Fluent Bit configuration and parsers for compatibility with Fluent Bit 5.x.
+- Improve Loki log formatting and remove unnecessary fields from exported logs.
+
 ## [5.9.0] - 2025-10-01
 
 - Use official metrics-server Helm chart, enable it by default and remove unneeded configuration.

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -23,7 +23,7 @@ config:
         Tag            kube.*
         Path           /var/log/containers/*.log
         Parser         cri
-        DB             /run/fluent-bit/flb_kube.db
+        DB             /var/log/flb_kube.db
         Mem_Buf_Limit  50MB
   ## https://docs.fluentbit.io/manual/pipeline/filters
   filters: |

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -1,7 +1,7 @@
 
 image:
-  repository: grafana/fluent-bit-plugin-loki
-  tag: 2.1.0-amd64
+  repository: cr.fluentbit.io/fluent/fluent-bit
+  tag: 5.0.3-amd64
   pullPolicy: IfNotPresent
 
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -44,10 +44,11 @@ config:
         Port 3100
         Uri /loki/api/v1/push
         Labels job=fluent-bit
-        Remove_Keys kubernetes,stream
+        Remove_Keys kubernetes,stream,logtag
         Auto_Kubernetes_Labels off
         Label_Map_Path /fluent-bit/etc/conf/labelmap.json
-        Line_Format key_value
+        Line_Format json
+        Drop_Single_Key raw
 
   # https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -44,7 +44,7 @@ config:
         Port 3100
         Uri /loki/api/v1/push
         Labels job=fluent-bit
-        RemoveKeys kubernetes,stream
+        Remove_Keys kubernetes,stream
         Auto_Kubernetes_Labels off
         Label_Map_Path /fluent-bit/etc/conf/labelmap.json
         Line_Format key_value

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -11,7 +11,7 @@ config:
         Daemon Off
         Flush {{ .Values.flush }}
         Log_Level {{ .Values.logLevel }}
-        Parsers_File /fluent-bit/etc/custom_parsers.conf
+        Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
         HTTP_Server On
         HTTP_Listen 0.0.0.0
         HTTP_Port {{ .Values.metricsPort }}
@@ -38,18 +38,16 @@ config:
   ## https://docs.fluentbit.io/manual/pipeline/outputs
   outputs: |
     [OUTPUT]
-        Name grafana-loki
+        Name loki
         Match *
-        Url http://loki-distributed-distributor:3100/api/prom/push
-        TenantID ""
-        BatchWait 1
-        BatchSize 1048576
-        Labels {job="fluent-bit"}
+        Host loki-distributed-distributor
+        Port 3100
+        Uri /loki/api/v1/push
+        Labels job=fluent-bit
         RemoveKeys kubernetes,stream
-        AutoKubernetesLabels false
-        LabelMapPath /fluent-bit/etc/labelmap.json
-        LineFormat key_value
-        LogLevel warn
+        Auto_Kubernetes_Labels off
+        Label_Map_Path /fluent-bit/etc/conf/labelmap.json
+        Line_Format key_value
 
   # https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -54,7 +54,7 @@ config:
     [PARSER]
         Name cri
         Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*)$
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
         Time_Key    time
         Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -1,7 +1,7 @@
 
 image:
   repository: cr.fluentbit.io/fluent/fluent-bit
-  tag: 5.0.3-amd64
+  tag: 5.0.2
   pullPolicy: IfNotPresent
 
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file

--- a/variables.tf
+++ b/variables.tf
@@ -567,7 +567,7 @@ variable "helm_fluent_bit_enabled" {
 }
 
 variable "fluent_bit_chart_version" {
-  default = "0.19.24"
+  default = "0.57.2"
 }
 
 variable "fluent_bit_priority_class_name" {


### PR DESCRIPTION
## [5.10.0] - 2026-04-16

- Upgrade Fluent Bit Helm chart from `0.19.24` to `0.57.2`.
- Upgrade Fluent Bit image to `cr.fluentbit.io/fluent/fluent-bit:5.0.2`.
- Replace Grafana Loki output plugin with the official Fluent Bit Loki plugin.
- Update Fluent Bit Loki output configuration to match the official plugin syntax.
- Fix parser configuration path for Fluent Bit 5.x compatibility.
- Fix Fluent Bit input database path persistence.
- Improve CRI parser regex to properly parse log payloads.
- Update Loki output formatting to JSON and remove unnecessary fields (`kubernetes`, `stream`, and `logtag`) from exported logs.