### PR TITLE
Add Envoy Gateway support and blackbox monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.10.0] - 2026-04-16
+
+- Upgrade Fluent Bit Helm chart to 0.57.2 and image to fluent-bit:5.0.2 versions.
+- Replace Grafana Loki plugin with the official Fluent Bit Loki output plugin.
+- Update Fluent Bit configuration and parsers for compatibility with Fluent Bit 5.x.
+- Improve Loki log formatting and remove unnecessary fields from exported logs.
+
 ## [5.9.0] - 2025-10-01
 
 - Use official metrics-server Helm chart, enable it by default and remove unneeded configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.11.0] - 2026-06-22
 
 - Add optional Envoy Gateway Helm deployment and Gateway API resources.
 - Add optional Prometheus blackbox exporter deployment with ServiceMonitor support for Kubernetes internet egress probes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Add optional Envoy Gateway Helm deployment and Gateway API resources.
+- Add optional Prometheus blackbox exporter deployment with ServiceMonitor support for Kubernetes internet egress probes.
+
 ## [5.10.0] - 2026-04-16
 
 - Upgrade Fluent Bit Helm chart to 0.57.2 and image to fluent-bit:5.0.2 versions.

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -23,13 +23,8 @@ config:
         Tag            kube.*
         Path           /var/log/containers/*.log
         Parser         cri
-<<<<<<< HEAD
-        DB             /run/fluent-bit/flb_kube.db
-        Mem_Buf_Limit  5MB
-=======
         DB             /var/log/flb_kube.db
         Mem_Buf_Limit  50MB
->>>>>>> ebf6a26 (Chore/update fluentbit (#60))
   ## https://docs.fluentbit.io/manual/pipeline/filters
   filters: |
     [FILTER]

--- a/helm-values/fluent-bit.yaml
+++ b/helm-values/fluent-bit.yaml
@@ -1,7 +1,7 @@
 
 image:
-  repository: grafana/fluent-bit-plugin-loki
-  tag: 2.1.0-amd64
+  repository: cr.fluentbit.io/fluent/fluent-bit
+  tag: 5.0.2
   pullPolicy: IfNotPresent
 
 ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file
@@ -11,7 +11,7 @@ config:
         Daemon Off
         Flush {{ .Values.flush }}
         Log_Level {{ .Values.logLevel }}
-        Parsers_File /fluent-bit/etc/custom_parsers.conf
+        Parsers_File /fluent-bit/etc/conf/custom_parsers.conf
         HTTP_Server On
         HTTP_Listen 0.0.0.0
         HTTP_Port {{ .Values.metricsPort }}
@@ -23,8 +23,13 @@ config:
         Tag            kube.*
         Path           /var/log/containers/*.log
         Parser         cri
+<<<<<<< HEAD
         DB             /run/fluent-bit/flb_kube.db
         Mem_Buf_Limit  5MB
+=======
+        DB             /var/log/flb_kube.db
+        Mem_Buf_Limit  50MB
+>>>>>>> ebf6a26 (Chore/update fluentbit (#60))
   ## https://docs.fluentbit.io/manual/pipeline/filters
   filters: |
     [FILTER]
@@ -38,25 +43,24 @@ config:
   ## https://docs.fluentbit.io/manual/pipeline/outputs
   outputs: |
     [OUTPUT]
-        Name grafana-loki
+        Name loki
         Match *
-        Url http://loki-distributed-distributor:3100/api/prom/push
-        TenantID ""
-        BatchWait 1
-        BatchSize 1048576
-        Labels {job="fluent-bit"}
-        RemoveKeys kubernetes,stream
-        AutoKubernetesLabels false
-        LabelMapPath /fluent-bit/etc/labelmap.json
-        LineFormat key_value
-        LogLevel warn
+        Host loki-distributed-distributor
+        Port 3100
+        Uri /loki/api/v1/push
+        Labels job=fluent-bit
+        Remove_Keys kubernetes,stream,logtag
+        Auto_Kubernetes_Labels off
+        Label_Map_Path /fluent-bit/etc/conf/labelmap.json
+        Line_Format json
+        Drop_Single_Key raw
 
   # https://docs.fluentbit.io/manual/pipeline/parsers
   customParsers: |
     [PARSER]
         Name cri
         Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*)$
+        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
         Time_Key    time
         Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 

--- a/helm.tf
+++ b/helm.tf
@@ -399,6 +399,48 @@ resource "helm_release" "prometheus_stack" {
 
 }
 
+resource "helm_release" "prometheus_blackbox_exporter" {
+  count            = var.helm_prometheus_blackbox_exporter_enabled ? 1 : 0
+  name             = var.prometheus_blackbox_exporter_release_name
+  namespace        = var.prometheus_blackbox_exporter_namespace
+  create_namespace = true
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "prometheus-blackbox-exporter"
+  version          = var.prometheus_blackbox_exporter_chart_version
+
+  values = [yamlencode({
+    serviceMonitor = {
+      enabled = var.prometheus_blackbox_exporter_service_monitor_enabled
+      defaults = {
+        labels = var.prometheus_blackbox_exporter_service_monitor_labels
+      }
+      targets = [
+        for target in var.prometheus_blackbox_exporter_http_targets : {
+          name   = trimsuffix(replace(replace(replace(replace(replace(target, "https://", ""), "http://", ""), "/", "-"), "_", "-"), ":", "-"), "-")
+          url    = target
+          module = "http_2xx"
+        }
+      ]
+    }
+
+    config = {
+      modules = {
+        http_2xx = {
+          prober  = "http"
+          timeout = var.prometheus_blackbox_exporter_http_timeout
+          http = {
+            method                = "GET"
+            preferred_ip_protocol = "ip4"
+            valid_status_codes    = []
+          }
+        }
+      }
+    }
+  })]
+
+  depends_on = [time_sleep.wait_20_seconds]
+}
+
 # ================== loki-distributed ================== #
 
 resource "helm_release" "loki_distributed" {

--- a/helm.tf
+++ b/helm.tf
@@ -148,6 +148,23 @@ resource "helm_release" "ingress_nginx_additional" {
 
 }
 
+resource "helm_release" "envoy_gateway" {
+  count            = var.helm_envoy_gateway_enabled ? 1 : 0
+  name             = var.envoy_gateway_release_name
+  namespace        = var.envoy_gateway_namespace
+  create_namespace = true
+  repository       = "oci://docker.io/envoyproxy"
+  chart            = "gateway-helm"
+  version          = var.envoy_gateway_chart_version
+
+  set {
+    name  = "deployment.replicas"
+    value = var.envoy_gateway_replicas
+  }
+
+  depends_on = [time_sleep.wait_20_seconds]
+}
+
 resource "helm_release" "cluster_autoscaler" {
   count      = var.helm_cluster_autoscaler_enabled ? 1 : 0
   name       = "cluster-autoscaler"

--- a/k8s-manifests/envoy-gateway-proxy-config.yaml.tpl
+++ b/k8s-manifests/envoy-gateway-proxy-config.yaml.tpl
@@ -1,0 +1,21 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        type: ${service_type}
+        externalTrafficPolicy: ${external_traffic_policy}
+%{ if nodeport_enabled ~}
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              ports:
+                - port: 80
+                  nodePort: ${http_nodeport}
+%{ endif ~}

--- a/k8s-manifests/envoy-gateway.yaml.tpl
+++ b/k8s-manifests/envoy-gateway.yaml.tpl
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${gateway_name}
+  namespace: ${namespace}
+spec:
+  gatewayClassName: ${gatewayclass_name}
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/k8s-manifests/envoy-gatewayclass.yaml.tpl
+++ b/k8s-manifests/envoy-gatewayclass.yaml.tpl
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: ${gatewayclass_name}
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: ${proxy_name}
+    namespace: ${namespace}

--- a/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl
+++ b/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl
@@ -21,7 +21,7 @@ spec:
         - action: keep
           sourceLabels:
             - __name__
-          regex: envoy_http_downstream_rq_total|envoy_http_downstream_rq_xx|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_xx|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count
+          regex: envoy_http_downstream_rq_total|envoy_http_downstream_rq_xx|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_xx|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count
         - action: replace
           sourceLabels:
             - envoy_cluster_name

--- a/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl
+++ b/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+  labels:
+    release: prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - ${namespace}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: envoy-metrics
+      envoy-metrics: ${metrics_scope}
+  endpoints:
+    - interval: 30s
+      path: /stats/prometheus
+      port: metrics
+      metricRelabelings:
+        - action: keep
+          sourceLabels:
+            - __name__
+          regex: envoy_http_downstream_rq_total|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count
+        - action: replace
+          sourceLabels:
+            - envoy_cluster_name
+          regex: httproute/([^/]+)/([^/]+)/.*
+          targetLabel: exported_namespace
+          replacement: $1
+        - action: replace
+          sourceLabels:
+            - envoy_cluster_name
+          regex: httproute/([^/]+)/([^/]+)/.*
+          targetLabel: exported_service
+          replacement: $2

--- a/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl
+++ b/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl
@@ -21,7 +21,7 @@ spec:
         - action: keep
           sourceLabels:
             - __name__
-          regex: envoy_http_downstream_rq_total|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count
+          regex: envoy_http_downstream_rq_total|envoy_http_downstream_rq_xx|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_xx|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count
         - action: replace
           sourceLabels:
             - envoy_cluster_name

--- a/k8s.tf
+++ b/k8s.tf
@@ -310,6 +310,13 @@ resource "kubernetes_manifest" "loki_gateway_httproute" {
     metadata = {
       name      = "loki-distributed-gateway"
       namespace = "monitoring"
+      labels = {
+        "app.kubernetes.io/component"  = "gateway"
+        "app.kubernetes.io/instance"   = "loki-distributed"
+        "app.kubernetes.io/managed-by" = "Helm"
+        "app.kubernetes.io/name"       = "loki-distributed"
+        "helm.sh/chart"                = "loki-distributed-${var.loki_chart_version}"
+      }
     }
     spec = {
       parentRefs = [
@@ -355,6 +362,15 @@ resource "kubernetes_manifest" "prometheus_httproute" {
     metadata = {
       name      = "prometheus-stack-kube-prom-prometheus"
       namespace = "monitoring"
+      labels = {
+        app                            = "kube-prometheus-stack-prometheus"
+        "app.kubernetes.io/instance"   = "prometheus-stack"
+        "app.kubernetes.io/managed-by" = "Helm"
+        "app.kubernetes.io/part-of"    = "kube-prometheus-stack"
+        chart                          = "kube-prometheus-stack-${var.prometheus_chart_version}"
+        heritage                       = "Helm"
+        release                        = "prometheus-stack"
+      }
     }
     spec = {
       parentRefs = [

--- a/k8s.tf
+++ b/k8s.tf
@@ -139,10 +139,6 @@ resource "kubernetes_manifest" "envoy_gateway_proxy_config" {
                         port     = 80
                         nodePort = var.envoy_gateway_http_nodeport
                       },
-                      {
-                        port     = 443
-                        nodePort = var.envoy_gateway_https_nodeport
-                      },
                     ]
                   }
                 }
@@ -269,10 +265,6 @@ resource "kubernetes_manifest" "envoy_internal_gateway_proxy_config" {
                         port     = 80
                         nodePort = var.envoy_internal_gateway_http_nodeport
                       },
-                      {
-                        port     = 443
-                        nodePort = var.envoy_internal_gateway_https_nodeport
-                      },
                     ]
                   }
                 }
@@ -319,4 +311,60 @@ resource "kubernetes_manifest" "envoy_internal_gateway" {
     kubernetes_manifest.envoy_internal_gatewayclass,
     kubernetes_manifest.envoy_internal_gateway_proxy_config,
   ]
+}
+
+resource "kubernetes_manifest" "envoy_cosun_backend_route" {
+  count = var.k8s_envoy_cosun_backend_route_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name      = "backend"
+      namespace = "cosun"
+      labels = {
+        app = "backend"
+      }
+    }
+    spec = {
+      parentRefs = [
+        {
+          name      = var.envoy_gateway_name
+          namespace = var.envoy_gateway_namespace
+        }
+      ]
+      hostnames = [var.envoy_cosun_backend_hostname]
+      rules = [
+        {
+          matches = [
+            {
+              path = {
+                type  = "PathPrefix"
+                value = "/"
+              }
+            }
+          ]
+          filters = [
+            {
+              type = "URLRewrite"
+              urlRewrite = {
+                path = {
+                  type            = "ReplaceFullPath"
+                  replaceFullPath = "/"
+                }
+              }
+            }
+          ]
+          backendRefs = [
+            {
+              name = "backend"
+              port = 80
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_manifest.envoy_gateway]
 }

--- a/k8s.tf
+++ b/k8s.tf
@@ -126,7 +126,8 @@ resource "kubernetes_manifest" "envoy_gateway_proxy_config" {
         kubernetes = {
           envoyService = merge(
             {
-              type = var.envoy_gateway_service_type
+              type                  = var.envoy_gateway_service_type
+              externalTrafficPolicy = var.envoy_gateway_external_traffic_policy
             },
             var.envoy_gateway_service_type == "NodePort" ? {
               patch = {
@@ -255,7 +256,8 @@ resource "kubernetes_manifest" "envoy_internal_gateway_proxy_config" {
         kubernetes = {
           envoyService = merge(
             {
-              type = var.envoy_internal_gateway_service_type
+              type                  = var.envoy_internal_gateway_service_type
+              externalTrafficPolicy = var.envoy_internal_gateway_external_traffic_policy
             },
             var.envoy_internal_gateway_service_type == "NodePort" ? {
               patch = {

--- a/k8s.tf
+++ b/k8s.tf
@@ -313,6 +313,198 @@ resource "kubernetes_manifest" "envoy_internal_gateway" {
   ]
 }
 
+resource "kubernetes_service_v1" "envoy_external_metrics_service" {
+  count = var.k8s_envoy_proxy_service_monitor_enabled ? 1 : 0
+
+  metadata {
+    name      = "envoy-external-metrics"
+    namespace = var.envoy_gateway_namespace
+    annotations = {
+      "prometheus.io/path"   = "/stats/prometheus"
+      "prometheus.io/port"   = "19001"
+      "prometheus.io/scrape" = "true"
+    }
+    labels = {
+      "app.kubernetes.io/name" = "envoy-metrics"
+      "envoy-metrics"          = "external"
+    }
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    port {
+      name        = "metrics"
+      port        = 19001
+      protocol    = "TCP"
+      target_port = "19001"
+    }
+
+    selector = {
+      "app.kubernetes.io/component"                    = "proxy"
+      "app.kubernetes.io/managed-by"                   = "envoy-gateway"
+      "app.kubernetes.io/name"                         = "envoy"
+      "gateway.envoyproxy.io/owning-gateway-name"      = var.envoy_gateway_name
+      "gateway.envoyproxy.io/owning-gateway-namespace" = var.envoy_gateway_namespace
+    }
+  }
+
+  depends_on = [kubernetes_manifest.envoy_gateway]
+}
+
+resource "kubernetes_service_v1" "envoy_internal_metrics_service" {
+  count = var.k8s_envoy_proxy_service_monitor_enabled && var.k8s_envoy_internal_gateway_enabled ? 1 : 0
+
+  metadata {
+    name      = "envoy-internal-metrics"
+    namespace = var.envoy_gateway_namespace
+    annotations = {
+      "prometheus.io/path"   = "/stats/prometheus"
+      "prometheus.io/port"   = "19001"
+      "prometheus.io/scrape" = "true"
+    }
+    labels = {
+      "app.kubernetes.io/name" = "envoy-metrics"
+      "envoy-metrics"          = "internal"
+    }
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    port {
+      name        = "metrics"
+      port        = 19001
+      protocol    = "TCP"
+      target_port = "19001"
+    }
+
+    selector = {
+      "app.kubernetes.io/component"                    = "proxy"
+      "app.kubernetes.io/managed-by"                   = "envoy-gateway"
+      "app.kubernetes.io/name"                         = "envoy"
+      "gateway.envoyproxy.io/owning-gateway-name"      = var.envoy_internal_gateway_name
+      "gateway.envoyproxy.io/owning-gateway-namespace" = var.envoy_gateway_namespace
+    }
+  }
+
+  depends_on = [kubernetes_manifest.envoy_internal_gateway]
+}
+
+resource "kubernetes_manifest" "envoy_external_metrics_service_monitor" {
+  count = var.k8s_envoy_proxy_service_monitor_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+    metadata = {
+      name      = "envoy-external-proxy"
+      namespace = var.envoy_gateway_namespace
+      labels = {
+        release = "prometheus-stack"
+      }
+    }
+    spec = {
+      namespaceSelector = {
+        matchNames = [var.envoy_gateway_namespace]
+      }
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name" = "envoy-metrics"
+          "envoy-metrics"          = "external"
+        }
+      }
+      endpoints = [
+        {
+          interval = "30s"
+          path     = "/stats/prometheus"
+          port     = "metrics"
+          metricRelabelings = [
+            {
+              action       = "keep"
+              sourceLabels = ["__name__"]
+              regex        = "envoy_http_downstream_rq_total|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count"
+            },
+            {
+              action       = "replace"
+              sourceLabels = ["envoy_cluster_name"]
+              regex        = "httproute/([^/]+)/([^/]+)/.*"
+              targetLabel  = "exported_namespace"
+              replacement  = "$1"
+            },
+            {
+              action       = "replace"
+              sourceLabels = ["envoy_cluster_name"]
+              regex        = "httproute/([^/]+)/([^/]+)/.*"
+              targetLabel  = "exported_service"
+              replacement  = "$2"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_service_v1.envoy_external_metrics_service]
+}
+
+resource "kubernetes_manifest" "envoy_internal_metrics_service_monitor" {
+  count = var.k8s_envoy_proxy_service_monitor_enabled && var.k8s_envoy_internal_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+    metadata = {
+      name      = "envoy-internal-proxy"
+      namespace = var.envoy_gateway_namespace
+      labels = {
+        release = "prometheus-stack"
+      }
+    }
+    spec = {
+      namespaceSelector = {
+        matchNames = [var.envoy_gateway_namespace]
+      }
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name" = "envoy-metrics"
+          "envoy-metrics"          = "internal"
+        }
+      }
+      endpoints = [
+        {
+          interval = "30s"
+          path     = "/stats/prometheus"
+          port     = "metrics"
+          metricRelabelings = [
+            {
+              action       = "keep"
+              sourceLabels = ["__name__"]
+              regex        = "envoy_http_downstream_rq_total|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count"
+            },
+            {
+              action       = "replace"
+              sourceLabels = ["envoy_cluster_name"]
+              regex        = "httproute/([^/]+)/([^/]+)/.*"
+              targetLabel  = "exported_namespace"
+              replacement  = "$1"
+            },
+            {
+              action       = "replace"
+              sourceLabels = ["envoy_cluster_name"]
+              regex        = "httproute/([^/]+)/([^/]+)/.*"
+              targetLabel  = "exported_service"
+              replacement  = "$2"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [kubernetes_service_v1.envoy_internal_metrics_service]
+}
+
 resource "kubernetes_manifest" "envoy_cosun_backend_route" {
   count = var.k8s_envoy_cosun_backend_route_enabled ? 1 : 0
 
@@ -341,17 +533,6 @@ resource "kubernetes_manifest" "envoy_cosun_backend_route" {
               path = {
                 type  = "PathPrefix"
                 value = "/"
-              }
-            }
-          ]
-          filters = [
-            {
-              type = "URLRewrite"
-              urlRewrite = {
-                path = {
-                  type            = "ReplaceFullPath"
-                  replaceFullPath = "/"
-                }
               }
             }
           ]

--- a/k8s.tf
+++ b/k8s.tf
@@ -113,42 +113,14 @@ resource "kubernetes_manifest" "otel-webhookvalidation" {
 resource "kubernetes_manifest" "envoy_gateway_proxy_config" {
   count = var.k8s_envoy_gateway_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "gateway.envoyproxy.io/v1alpha1"
-    kind       = "EnvoyProxy"
-    metadata = {
-      name      = var.envoy_gateway_name
-      namespace = var.envoy_gateway_namespace
-    }
-    spec = {
-      provider = {
-        type = "Kubernetes"
-        kubernetes = {
-          envoyService = merge(
-            {
-              type                  = var.envoy_gateway_service_type
-              externalTrafficPolicy = var.envoy_gateway_external_traffic_policy
-            },
-            var.envoy_gateway_service_type == "NodePort" ? {
-              patch = {
-                type = "StrategicMerge"
-                value = {
-                  spec = {
-                    ports = [
-                      {
-                        port     = 80
-                        nodePort = var.envoy_gateway_http_nodeport
-                      },
-                    ]
-                  }
-                }
-              }
-            } : {}
-          )
-        }
-      }
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-gateway-proxy-config.yaml.tpl", {
+    name                    = var.envoy_gateway_name
+    namespace               = var.envoy_gateway_namespace
+    service_type            = var.envoy_gateway_service_type
+    external_traffic_policy = var.envoy_gateway_external_traffic_policy
+    nodeport_enabled        = var.envoy_gateway_service_type == "NodePort"
+    http_nodeport           = var.envoy_gateway_http_nodeport
+  }))
 
   depends_on = [helm_release.envoy_gateway]
 }
@@ -156,22 +128,11 @@ resource "kubernetes_manifest" "envoy_gateway_proxy_config" {
 resource "kubernetes_manifest" "envoy_gatewayclass" {
   count = var.k8s_envoy_gateway_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "gateway.networking.k8s.io/v1"
-    kind       = "GatewayClass"
-    metadata = {
-      name = var.envoy_gatewayclass_name
-    }
-    spec = {
-      controllerName = "gateway.envoyproxy.io/gatewayclass-controller"
-      parametersRef = {
-        group     = "gateway.envoyproxy.io"
-        kind      = "EnvoyProxy"
-        name      = var.envoy_gateway_name
-        namespace = var.envoy_gateway_namespace
-      }
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-gatewayclass.yaml.tpl", {
+    gatewayclass_name = var.envoy_gatewayclass_name
+    proxy_name        = var.envoy_gateway_name
+    namespace         = var.envoy_gateway_namespace
+  }))
 
   depends_on = [helm_release.envoy_gateway]
 }
@@ -179,29 +140,11 @@ resource "kubernetes_manifest" "envoy_gatewayclass" {
 resource "kubernetes_manifest" "envoy_gateway" {
   count = var.k8s_envoy_gateway_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "gateway.networking.k8s.io/v1"
-    kind       = "Gateway"
-    metadata = {
-      name      = var.envoy_gateway_name
-      namespace = var.envoy_gateway_namespace
-    }
-    spec = {
-      gatewayClassName = var.envoy_gatewayclass_name
-      listeners = [
-        {
-          name     = "http"
-          protocol = "HTTP"
-          port     = 80
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-          }
-        }
-      ]
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-gateway.yaml.tpl", {
+    gateway_name      = var.envoy_gateway_name
+    namespace         = var.envoy_gateway_namespace
+    gatewayclass_name = var.envoy_gatewayclass_name
+  }))
 
   depends_on = [
     helm_release.envoy_gateway,
@@ -213,22 +156,11 @@ resource "kubernetes_manifest" "envoy_gateway" {
 resource "kubernetes_manifest" "envoy_internal_gatewayclass" {
   count = var.k8s_envoy_internal_gateway_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "gateway.networking.k8s.io/v1"
-    kind       = "GatewayClass"
-    metadata = {
-      name = var.envoy_internal_gatewayclass_name
-    }
-    spec = {
-      controllerName = "gateway.envoyproxy.io/gatewayclass-controller"
-      parametersRef = {
-        group     = "gateway.envoyproxy.io"
-        kind      = "EnvoyProxy"
-        name      = var.envoy_internal_gateway_name
-        namespace = var.envoy_gateway_namespace
-      }
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-gatewayclass.yaml.tpl", {
+    gatewayclass_name = var.envoy_internal_gatewayclass_name
+    proxy_name        = var.envoy_internal_gateway_name
+    namespace         = var.envoy_gateway_namespace
+  }))
 
   depends_on = [
     helm_release.envoy_gateway,
@@ -239,42 +171,14 @@ resource "kubernetes_manifest" "envoy_internal_gatewayclass" {
 resource "kubernetes_manifest" "envoy_internal_gateway_proxy_config" {
   count = var.k8s_envoy_internal_gateway_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "gateway.envoyproxy.io/v1alpha1"
-    kind       = "EnvoyProxy"
-    metadata = {
-      name      = var.envoy_internal_gateway_name
-      namespace = var.envoy_gateway_namespace
-    }
-    spec = {
-      provider = {
-        type = "Kubernetes"
-        kubernetes = {
-          envoyService = merge(
-            {
-              type                  = var.envoy_internal_gateway_service_type
-              externalTrafficPolicy = var.envoy_internal_gateway_external_traffic_policy
-            },
-            var.envoy_internal_gateway_service_type == "NodePort" ? {
-              patch = {
-                type = "StrategicMerge"
-                value = {
-                  spec = {
-                    ports = [
-                      {
-                        port     = 80
-                        nodePort = var.envoy_internal_gateway_http_nodeport
-                      },
-                    ]
-                  }
-                }
-              }
-            } : {}
-          )
-        }
-      }
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-gateway-proxy-config.yaml.tpl", {
+    name                    = var.envoy_internal_gateway_name
+    namespace               = var.envoy_gateway_namespace
+    service_type            = var.envoy_internal_gateway_service_type
+    external_traffic_policy = var.envoy_internal_gateway_external_traffic_policy
+    nodeport_enabled        = var.envoy_internal_gateway_service_type == "NodePort"
+    http_nodeport           = var.envoy_internal_gateway_http_nodeport
+  }))
 
   depends_on = [helm_release.envoy_gateway]
 }
@@ -282,29 +186,11 @@ resource "kubernetes_manifest" "envoy_internal_gateway_proxy_config" {
 resource "kubernetes_manifest" "envoy_internal_gateway" {
   count = var.k8s_envoy_internal_gateway_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "gateway.networking.k8s.io/v1"
-    kind       = "Gateway"
-    metadata = {
-      name      = var.envoy_internal_gateway_name
-      namespace = var.envoy_gateway_namespace
-    }
-    spec = {
-      gatewayClassName = var.envoy_internal_gatewayclass_name
-      listeners = [
-        {
-          name     = "http"
-          protocol = "HTTP"
-          port     = 80
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-          }
-        }
-      ]
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-gateway.yaml.tpl", {
+    gateway_name      = var.envoy_internal_gateway_name
+    namespace         = var.envoy_gateway_namespace
+    gatewayclass_name = var.envoy_internal_gatewayclass_name
+  }))
 
   depends_on = [
     helm_release.envoy_gateway,
@@ -394,56 +280,11 @@ resource "kubernetes_service_v1" "envoy_internal_metrics_service" {
 resource "kubernetes_manifest" "envoy_external_metrics_service_monitor" {
   count = var.k8s_envoy_proxy_service_monitor_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "monitoring.coreos.com/v1"
-    kind       = "ServiceMonitor"
-    metadata = {
-      name      = "envoy-external-proxy"
-      namespace = var.envoy_gateway_namespace
-      labels = {
-        release = "prometheus-stack"
-      }
-    }
-    spec = {
-      namespaceSelector = {
-        matchNames = [var.envoy_gateway_namespace]
-      }
-      selector = {
-        matchLabels = {
-          "app.kubernetes.io/name" = "envoy-metrics"
-          "envoy-metrics"          = "external"
-        }
-      }
-      endpoints = [
-        {
-          interval = "30s"
-          path     = "/stats/prometheus"
-          port     = "metrics"
-          metricRelabelings = [
-            {
-              action       = "keep"
-              sourceLabels = ["__name__"]
-              regex        = "envoy_http_downstream_rq_total|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count"
-            },
-            {
-              action       = "replace"
-              sourceLabels = ["envoy_cluster_name"]
-              regex        = "httproute/([^/]+)/([^/]+)/.*"
-              targetLabel  = "exported_namespace"
-              replacement  = "$1"
-            },
-            {
-              action       = "replace"
-              sourceLabels = ["envoy_cluster_name"]
-              regex        = "httproute/([^/]+)/([^/]+)/.*"
-              targetLabel  = "exported_service"
-              replacement  = "$2"
-            }
-          ]
-        }
-      ]
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl", {
+    name          = "envoy-external-proxy"
+    namespace     = var.envoy_gateway_namespace
+    metrics_scope = "external"
+  }))
 
   depends_on = [kubernetes_service_v1.envoy_external_metrics_service]
 }
@@ -451,101 +292,11 @@ resource "kubernetes_manifest" "envoy_external_metrics_service_monitor" {
 resource "kubernetes_manifest" "envoy_internal_metrics_service_monitor" {
   count = var.k8s_envoy_proxy_service_monitor_enabled && var.k8s_envoy_internal_gateway_enabled ? 1 : 0
 
-  manifest = {
-    apiVersion = "monitoring.coreos.com/v1"
-    kind       = "ServiceMonitor"
-    metadata = {
-      name      = "envoy-internal-proxy"
-      namespace = var.envoy_gateway_namespace
-      labels = {
-        release = "prometheus-stack"
-      }
-    }
-    spec = {
-      namespaceSelector = {
-        matchNames = [var.envoy_gateway_namespace]
-      }
-      selector = {
-        matchLabels = {
-          "app.kubernetes.io/name" = "envoy-metrics"
-          "envoy-metrics"          = "internal"
-        }
-      }
-      endpoints = [
-        {
-          interval = "30s"
-          path     = "/stats/prometheus"
-          port     = "metrics"
-          metricRelabelings = [
-            {
-              action       = "keep"
-              sourceLabels = ["__name__"]
-              regex        = "envoy_http_downstream_rq_total|envoy_http_downstream_rq_time_bucket|envoy_http_downstream_rq_time_sum|envoy_http_downstream_rq_time_count|envoy_cluster_upstream_rq_total|envoy_cluster_upstream_rq_time_bucket|envoy_cluster_upstream_rq_time_sum|envoy_cluster_upstream_rq_time_count"
-            },
-            {
-              action       = "replace"
-              sourceLabels = ["envoy_cluster_name"]
-              regex        = "httproute/([^/]+)/([^/]+)/.*"
-              targetLabel  = "exported_namespace"
-              replacement  = "$1"
-            },
-            {
-              action       = "replace"
-              sourceLabels = ["envoy_cluster_name"]
-              regex        = "httproute/([^/]+)/([^/]+)/.*"
-              targetLabel  = "exported_service"
-              replacement  = "$2"
-            }
-          ]
-        }
-      ]
-    }
-  }
+  manifest = yamldecode(templatefile("${path.module}/k8s-manifests/envoy-metrics-servicemonitor.yaml.tpl", {
+    name          = "envoy-internal-proxy"
+    namespace     = var.envoy_gateway_namespace
+    metrics_scope = "internal"
+  }))
 
   depends_on = [kubernetes_service_v1.envoy_internal_metrics_service]
-}
-
-resource "kubernetes_manifest" "envoy_cosun_backend_route" {
-  count = var.k8s_envoy_cosun_backend_route_enabled ? 1 : 0
-
-  manifest = {
-    apiVersion = "gateway.networking.k8s.io/v1"
-    kind       = "HTTPRoute"
-    metadata = {
-      name      = "backend"
-      namespace = "cosun"
-      labels = {
-        app = "backend"
-      }
-    }
-    spec = {
-      parentRefs = [
-        {
-          name      = var.envoy_gateway_name
-          namespace = var.envoy_gateway_namespace
-        }
-      ]
-      hostnames = [var.envoy_cosun_backend_hostname]
-      rules = [
-        {
-          matches = [
-            {
-              path = {
-                type  = "PathPrefix"
-                value = "/"
-              }
-            }
-          ]
-          backendRefs = [
-            {
-              name = "backend"
-              port = 80
-            }
-          ]
-        }
-      ]
-    }
-  }
-
-  depends_on = [kubernetes_manifest.envoy_gateway]
 }

--- a/k8s.tf
+++ b/k8s.tf
@@ -300,3 +300,93 @@ resource "kubernetes_manifest" "envoy_internal_metrics_service_monitor" {
 
   depends_on = [kubernetes_service_v1.envoy_internal_metrics_service]
 }
+
+resource "kubernetes_manifest" "loki_gateway_httproute" {
+  count = var.helm_loki_enabled && var.loki_gateway_enabled && var.loki_gateway_ingress_enabled && var.k8s_envoy_internal_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name      = "loki-distributed-gateway"
+      namespace = "monitoring"
+    }
+    spec = {
+      parentRefs = [
+        {
+          name      = var.envoy_internal_gateway_name
+          namespace = var.envoy_gateway_namespace
+        }
+      ]
+      hostnames = [var.loki_gateway_ingress_host]
+      rules = [
+        {
+          matches = [
+            {
+              path = {
+                type  = "PathPrefix"
+                value = var.loki_gateway_ingress_path
+              }
+            }
+          ]
+          backendRefs = [
+            {
+              name = "loki-distributed-gateway"
+              port = 80
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    helm_release.loki_distributed,
+    kubernetes_manifest.envoy_internal_gateway,
+  ]
+}
+
+resource "kubernetes_manifest" "prometheus_httproute" {
+  count = var.helm_prometheus_enabled && var.prometheus_ingress_enabled && var.k8s_envoy_internal_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name      = "prometheus-stack-kube-prom-prometheus"
+      namespace = "monitoring"
+    }
+    spec = {
+      parentRefs = [
+        {
+          name      = var.envoy_internal_gateway_name
+          namespace = var.envoy_gateway_namespace
+        }
+      ]
+      hostnames = [var.prometheus_ingress_host]
+      rules = [
+        {
+          matches = [
+            {
+              path = {
+                type  = "PathPrefix"
+                value = var.prometheus_ingress_path
+              }
+            }
+          ]
+          backendRefs = [
+            {
+              name = "prometheus-stack-kube-prom-prometheus"
+              port = 9090
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    helm_release.prometheus_stack,
+    kubernetes_manifest.envoy_internal_gateway,
+  ]
+}

--- a/k8s.tf
+++ b/k8s.tf
@@ -1,111 +1,320 @@
 # These manifests have been taken from https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
 
 resource "kubernetes_manifest" "otel-cert-operator-serving" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-cert-operator-serving.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-cert-operator-serving.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrolebinding-operator-manager" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrolebinding-operator-manager.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrolebinding-operator-manager.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrolebinding-operator-proxy" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrolebinding-operator-proxy.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrolebinding-operator-proxy.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrole-operator-manager" {
-  count             = var.k8s_opentelemetry_enabled ? 1 : 0
+  count    = var.k8s_opentelemetry_enabled ? 1 : 0
   manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-manager.yaml"))
 
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrole-operator-metrics-reader" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-metrics-reader.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-metrics-reader.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-clusterrole-operator-proxy" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-proxy.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-clusterrole-operator-proxy.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-crd-collectors" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-crd-collectors.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-crd-collectors.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-crd-instrumentations" {
-  count             = var.k8s_opentelemetry_enabled ? 1 : 0
+  count    = var.k8s_opentelemetry_enabled ? 1 : 0
   manifest = yamldecode(file("${path.module}/k8s-manifests/otel-crd-instrumentations.yaml"))
-   
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-deployment-operator-controller-manager" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-deployment-operator-controller-manager.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-deployment-operator-controller-manager.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-issuer-operator-selfsigned" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-issuer-operator-selfsigned.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-issuer-operator-selfsigned.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
-resource "kubernetes_manifest" "otel-ns-operator-system" { 
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-ns-operator-system.yaml"))
-    depends_on = [helm_release.cert_manager]
+resource "kubernetes_manifest" "otel-ns-operator-system" {
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-ns-operator-system.yaml"))
+  depends_on = [helm_release.cert_manager]
 }
 
 resource "kubernetes_manifest" "otel-rolebinding-operator-leader-election" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-rolebinding-operator-leader-election.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-rolebinding-operator-leader-election.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-role-operator-system" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-role-operator-system.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-role-operator-system.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-sa-operator-controller-manager" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-sa-operator-controller-manager.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-sa-operator-controller-manager.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-svc-operator-controller-manager" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-svc-operator-controller-manager.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-svc-operator-controller-manager.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-svc-operator-webhook" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-svc-operator-webhook.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-svc-operator-webhook.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-webhookconfig" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-webhookconfig.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-webhookconfig.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
 }
 
 resource "kubernetes_manifest" "otel-webhookvalidation" {
-    count             = var.k8s_opentelemetry_enabled ? 1 : 0
-    manifest = yamldecode(file("${path.module}/k8s-manifests/otel-webhookvalidation.yaml"))
-    depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+  count      = var.k8s_opentelemetry_enabled ? 1 : 0
+  manifest   = yamldecode(file("${path.module}/k8s-manifests/otel-webhookvalidation.yaml"))
+  depends_on = [helm_release.cert_manager, kubernetes_manifest.otel-ns-operator-system]
+}
+
+resource "kubernetes_manifest" "envoy_gateway_proxy_config" {
+  count = var.k8s_envoy_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.envoyproxy.io/v1alpha1"
+    kind       = "EnvoyProxy"
+    metadata = {
+      name      = var.envoy_gateway_name
+      namespace = var.envoy_gateway_namespace
+    }
+    spec = {
+      provider = {
+        type = "Kubernetes"
+        kubernetes = {
+          envoyService = merge(
+            {
+              type = var.envoy_gateway_service_type
+            },
+            var.envoy_gateway_service_type == "NodePort" ? {
+              patch = {
+                type = "StrategicMerge"
+                value = {
+                  spec = {
+                    ports = [
+                      {
+                        port     = 80
+                        nodePort = var.envoy_gateway_http_nodeport
+                      },
+                      {
+                        port     = 443
+                        nodePort = var.envoy_gateway_https_nodeport
+                      },
+                    ]
+                  }
+                }
+              }
+            } : {}
+          )
+        }
+      }
+    }
+  }
+
+  depends_on = [helm_release.envoy_gateway]
+}
+
+resource "kubernetes_manifest" "envoy_gatewayclass" {
+  count = var.k8s_envoy_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "GatewayClass"
+    metadata = {
+      name = var.envoy_gatewayclass_name
+    }
+    spec = {
+      controllerName = "gateway.envoyproxy.io/gatewayclass-controller"
+      parametersRef = {
+        group     = "gateway.envoyproxy.io"
+        kind      = "EnvoyProxy"
+        name      = var.envoy_gateway_name
+        namespace = var.envoy_gateway_namespace
+      }
+    }
+  }
+
+  depends_on = [helm_release.envoy_gateway]
+}
+
+resource "kubernetes_manifest" "envoy_gateway" {
+  count = var.k8s_envoy_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = var.envoy_gateway_name
+      namespace = var.envoy_gateway_namespace
+    }
+    spec = {
+      gatewayClassName = var.envoy_gatewayclass_name
+      listeners = [
+        {
+          name     = "http"
+          protocol = "HTTP"
+          port     = 80
+          allowedRoutes = {
+            namespaces = {
+              from = "All"
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    helm_release.envoy_gateway,
+    kubernetes_manifest.envoy_gateway_proxy_config,
+    kubernetes_manifest.envoy_gatewayclass,
+  ]
+}
+
+resource "kubernetes_manifest" "envoy_internal_gatewayclass" {
+  count = var.k8s_envoy_internal_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "GatewayClass"
+    metadata = {
+      name = var.envoy_internal_gatewayclass_name
+    }
+    spec = {
+      controllerName = "gateway.envoyproxy.io/gatewayclass-controller"
+      parametersRef = {
+        group     = "gateway.envoyproxy.io"
+        kind      = "EnvoyProxy"
+        name      = var.envoy_internal_gateway_name
+        namespace = var.envoy_gateway_namespace
+      }
+    }
+  }
+
+  depends_on = [
+    helm_release.envoy_gateway,
+    kubernetes_manifest.envoy_internal_gateway_proxy_config,
+  ]
+}
+
+resource "kubernetes_manifest" "envoy_internal_gateway_proxy_config" {
+  count = var.k8s_envoy_internal_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.envoyproxy.io/v1alpha1"
+    kind       = "EnvoyProxy"
+    metadata = {
+      name      = var.envoy_internal_gateway_name
+      namespace = var.envoy_gateway_namespace
+    }
+    spec = {
+      provider = {
+        type = "Kubernetes"
+        kubernetes = {
+          envoyService = merge(
+            {
+              type = var.envoy_internal_gateway_service_type
+            },
+            var.envoy_internal_gateway_service_type == "NodePort" ? {
+              patch = {
+                type = "StrategicMerge"
+                value = {
+                  spec = {
+                    ports = [
+                      {
+                        port     = 80
+                        nodePort = var.envoy_internal_gateway_http_nodeport
+                      },
+                      {
+                        port     = 443
+                        nodePort = var.envoy_internal_gateway_https_nodeport
+                      },
+                    ]
+                  }
+                }
+              }
+            } : {}
+          )
+        }
+      }
+    }
+  }
+
+  depends_on = [helm_release.envoy_gateway]
+}
+
+resource "kubernetes_manifest" "envoy_internal_gateway" {
+  count = var.k8s_envoy_internal_gateway_enabled ? 1 : 0
+
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = var.envoy_internal_gateway_name
+      namespace = var.envoy_gateway_namespace
+    }
+    spec = {
+      gatewayClassName = var.envoy_internal_gatewayclass_name
+      listeners = [
+        {
+          name     = "http"
+          protocol = "HTTP"
+          port     = 80
+          allowedRoutes = {
+            namespaces = {
+              from = "All"
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    helm_release.envoy_gateway,
+    kubernetes_manifest.envoy_internal_gatewayclass,
+    kubernetes_manifest.envoy_internal_gateway_proxy_config,
+  ]
 }

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,9 @@
+moved {
+  from = module.ebs_csi_controller_role.aws_iam_role.this[0]
+  to   = module.ebs_csi_controller_role[0].aws_iam_role.this[0]
+}
+
+moved {
+  from = module.ebs_csi_controller_role.aws_iam_role_policy_attachment.custom[0]
+  to   = module.ebs_csi_controller_role[0].aws_iam_role_policy_attachment.custom[0]
+}

--- a/nodegroups.tf
+++ b/nodegroups.tf
@@ -137,6 +137,7 @@ resource "aws_autoscaling_group" "eks" {
   vpc_zone_identifier = each.value.subnets_ids
   target_group_arns   = var.target_group_arns
   health_check_type   = var.health_check_type
+  capacity_rebalance  = each.value.spot_nodes_enabled == true ? var.capacity_rebalance : null
 
   mixed_instances_policy {
     dynamic "instances_distribution" {
@@ -152,6 +153,13 @@ resource "aws_autoscaling_group" "eks" {
       launch_template_specification {
         launch_template_id = aws_launch_template.eks_node_groups[each.key].id
         version            = "$Latest"
+      }
+
+      dynamic "override" {
+        for_each = each.value.spot_nodes_enabled == true && each.value.instance_type_overrides != null ? each.value.instance_type_overrides : []
+        content {
+          instance_type = override.value
+        }
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -22,18 +22,19 @@ variable "custom_node_groups" {
   type = list(object({
     name = string
     values = object({
-      ami_id           = string,
-      instance_type    = string,
-      workers_public   = bool,
-      extra_sg_ids     = optional(list(string)),
-      instance_profile = optional(string),
-      asg_min          = number,
-      asg_max          = number,
-      subnets_ids      = list(string),
-      volume_type      = string,
-      volume_size      = number,
-      volume_iops      = optional(number),
-      k8s_labels       = optional(map(string)),
+      ami_id                  = string,
+      instance_type           = string,
+      instance_type_overrides = optional(list(string)),
+      workers_public          = bool,
+      extra_sg_ids            = optional(list(string)),
+      instance_profile        = optional(string),
+      asg_min                 = number,
+      asg_max                 = number,
+      subnets_ids             = list(string),
+      volume_type             = string,
+      volume_size             = number,
+      volume_iops             = optional(number),
+      k8s_labels              = optional(map(string)),
       asg_tags = optional(list(object({
         key   = string,
         value = string,
@@ -89,6 +90,10 @@ variable "on_demand_percentage_above_base_capacity" {
 
 variable "spot_allocation_strategy" {
   default = "capacity-optimized"
+}
+
+variable "capacity_rebalance" {
+  default = false
 }
 
 variable "spot_instance_pools" {

--- a/variables.tf
+++ b/variables.tf
@@ -321,14 +321,6 @@ variable "envoy_internal_gateway_external_traffic_policy" {
   default = "Cluster"
 }
 
-variable "k8s_envoy_cosun_backend_route_enabled" {
-  default = false
-}
-
-variable "envoy_cosun_backend_hostname" {
-  default = "pildoc.dev.digidocapi.com"
-}
-
 variable "k8s_envoy_proxy_service_monitor_enabled" {
   default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -243,6 +243,28 @@ variable "helm_ingress_nginx_additional_enabled" {
   default = false
 }
 
+# ================== envoy gateway =================
+
+variable "helm_envoy_gateway_enabled" {
+  default = false
+}
+
+variable "envoy_gateway_chart_version" {
+  default = "v1.7.1"
+}
+
+variable "envoy_gateway_namespace" {
+  default = "envoy"
+}
+
+variable "envoy_gateway_release_name" {
+  default = "envoy-gateway"
+}
+
+variable "envoy_gateway_replicas" {
+  default = 1
+}
+
 variable "ingress_additional_http_nodeport" {
   default = 31080
 }

--- a/variables.tf
+++ b/variables.tf
@@ -265,6 +265,54 @@ variable "envoy_gateway_replicas" {
   default = 1
 }
 
+variable "k8s_envoy_gateway_enabled" {
+  default = false
+}
+
+variable "envoy_gatewayclass_name" {
+  default = "envoy-external"
+}
+
+variable "envoy_internal_gatewayclass_name" {
+  default = "envoy-internal"
+}
+
+variable "envoy_gateway_name" {
+  default = "envoy-external"
+}
+
+variable "envoy_gateway_service_type" {
+  default = "ClusterIP"
+}
+
+variable "envoy_gateway_http_nodeport" {
+  default = 30080
+}
+
+variable "envoy_gateway_https_nodeport" {
+  default = 30443
+}
+
+variable "k8s_envoy_internal_gateway_enabled" {
+  default = false
+}
+
+variable "envoy_internal_gateway_name" {
+  default = "envoy-internal"
+}
+
+variable "envoy_internal_gateway_service_type" {
+  default = "ClusterIP"
+}
+
+variable "envoy_internal_gateway_http_nodeport" {
+  default = 30180
+}
+
+variable "envoy_internal_gateway_https_nodeport" {
+  default = 30543
+}
+
 variable "ingress_additional_http_nodeport" {
   default = 31080
 }

--- a/variables.tf
+++ b/variables.tf
@@ -654,7 +654,7 @@ variable "helm_fluent_bit_enabled" {
 }
 
 variable "fluent_bit_chart_version" {
-  default = "0.19.24"
+  default = "0.57.2"
 }
 
 variable "fluent_bit_priority_class_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -329,6 +329,10 @@ variable "envoy_cosun_backend_hostname" {
   default = "pildoc.dev.digidocapi.com"
 }
 
+variable "k8s_envoy_proxy_service_monitor_enabled" {
+  default = false
+}
+
 variable "ingress_additional_http_nodeport" {
   default = 31080
 }

--- a/variables.tf
+++ b/variables.tf
@@ -736,6 +736,43 @@ variable "prometheus_additional_scrape_configs" {
   default = ""
 }
 
+# ================== prometheus-blackbox-exporter ================== #
+variable "helm_prometheus_blackbox_exporter_enabled" {
+  default = false
+}
+
+variable "prometheus_blackbox_exporter_chart_version" {
+  default = "9.0.0"
+}
+
+variable "prometheus_blackbox_exporter_release_name" {
+  default = "blackbox-exporter"
+}
+
+variable "prometheus_blackbox_exporter_namespace" {
+  default = "monitoring"
+}
+
+variable "prometheus_blackbox_exporter_service_monitor_enabled" {
+  default = true
+}
+
+variable "prometheus_blackbox_exporter_service_monitor_labels" {
+  type = map(string)
+  default = {
+    release = "prometheus"
+  }
+}
+
+variable "prometheus_blackbox_exporter_http_targets" {
+  type    = list(string)
+  default = []
+}
+
+variable "prometheus_blackbox_exporter_http_timeout" {
+  default = "5s"
+}
+
 # ================== tempo ================== #
 variable "helm_tempo_enabled" {
   default = false

--- a/variables.tf
+++ b/variables.tf
@@ -293,6 +293,10 @@ variable "envoy_gateway_https_nodeport" {
   default = 30443
 }
 
+variable "envoy_gateway_external_traffic_policy" {
+  default = "Cluster"
+}
+
 variable "k8s_envoy_internal_gateway_enabled" {
   default = false
 }
@@ -311,6 +315,10 @@ variable "envoy_internal_gateway_http_nodeport" {
 
 variable "envoy_internal_gateway_https_nodeport" {
   default = 30543
+}
+
+variable "envoy_internal_gateway_external_traffic_policy" {
+  default = "Cluster"
 }
 
 variable "ingress_additional_http_nodeport" {

--- a/variables.tf
+++ b/variables.tf
@@ -321,6 +321,14 @@ variable "envoy_internal_gateway_external_traffic_policy" {
   default = "Cluster"
 }
 
+variable "k8s_envoy_cosun_backend_route_enabled" {
+  default = false
+}
+
+variable "envoy_cosun_backend_hostname" {
+  default = "pildoc.dev.digidocapi.com"
+}
+
 variable "ingress_additional_http_nodeport" {
   default = 31080
 }


### PR DESCRIPTION
## Summary
- Add optional Envoy Gateway deployment and Gateway API resources.
- Add Envoy metrics ServiceMonitor resources and related relabeling.
- Add optional Prometheus blackbox exporter deployment with ServiceMonitor support for internet egress probes.
- Update CHANGELOG with unreleased Envoy and blackbox exporter entries.

## Validation
- terraform init -backend=false && terraform validate
- terraspace plan eks from platform dev stack confirmed creation of module.eks_main.helm_release.prometheus_blackbox_exporter[0]

## Notes
- Blackbox exporter is disabled by default and configured through module inputs.
- Grafana alerts can be built from probe_success metrics exposed through Prometheus.